### PR TITLE
Prevent uneven trace samples

### DIFF
--- a/NuRadioReco/framework/base_trace.py
+++ b/NuRadioReco/framework/base_trace.py
@@ -53,6 +53,12 @@ class BaseTrace:
         sampling_rate: float
             the sampling rage of the trace, i.e., the inverse of the bin width
         """
+        if trace is not None:
+            if trace.shape[trace.ndim - 1]%2 != 0:
+                if trace.ndim == 1:
+                    trace = np.append(trace, 0)
+                else:
+                    trace = np.append(trace, np.zeros((trace.shape[0], 1)), axis=1)
         self.__time_domain_up_to_date = True
         self._time_trace = trace
         self._sampling_rate = sampling_rate

--- a/NuRadioReco/framework/base_trace.py
+++ b/NuRadioReco/framework/base_trace.py
@@ -31,6 +31,7 @@ class BaseTrace:
 #             logger.debug("time domain is not up to date, calculating FFT on the fly")
             self._time_trace = fft.freq2time(self._frequency_spectrum)
             self.__time_domain_up_to_date = True
+            self._frequency_spectrum = None
         return self._time_trace
 
     def get_frequency_spectrum(self):
@@ -38,6 +39,7 @@ class BaseTrace:
 #             logger.debug("frequency domain is not up to date, calculating FFT on the fly")
 #             logger.debug("time trace has shape {}".format(self._time_trace.shape))
             self._frequency_spectrum = fft.time2freq(self._time_trace)
+            self._time_trace = None
 #             logger.debug("frequency spectrum has shape {}".format(self._frequency_spectrum.shape))
             self.__time_domain_up_to_date = False
         return self._frequency_spectrum

--- a/NuRadioReco/framework/base_trace.py
+++ b/NuRadioReco/framework/base_trace.py
@@ -57,10 +57,7 @@ class BaseTrace:
         """
         if trace is not None:
             if trace.shape[trace.ndim - 1]%2 != 0:
-                if trace.ndim == 1:
-                    trace = np.append(trace, 0)
-                else:
-                    trace = np.append(trace, np.zeros((trace.shape[0], 1)), axis=1)
+                raise ValueError('Attempted to set trace with an uneven number ({}) of samples. Only traces with an even number of samples are allowed.'.format(trace.shape[trace.ndim - 1]))
         self.__time_domain_up_to_date = True
         self._time_trace = trace
         self._sampling_rate = sampling_rate

--- a/NuRadioReco/modules/stationResampler.py
+++ b/NuRadioReco/modules/stationResampler.py
@@ -44,6 +44,7 @@ class stationResampler:
                 trace = signal.resample(trace, len(trace) / resampling_factor.denominator)  # , window='hann')
 
             resampled_efield[iE] = trace
+        # prevent traces to get an odd number of samples. If the trae has an odd number of samples, the last sample is discarded.
         if resampled_efield.shape[-1] % 2 != 0:
             resampled_efield = resampled_efield.T[:-1].T
         station.set_trace(resampled_efield, sampling_rate)

--- a/NuRadioReco/modules/stationResampler.py
+++ b/NuRadioReco/modules/stationResampler.py
@@ -44,7 +44,8 @@ class stationResampler:
                 trace = signal.resample(trace, len(trace) / resampling_factor.denominator)  # , window='hann')
 
             resampled_efield[iE] = trace
-
+        if resampled_efield.shape[-1] % 2 != 0:
+            resampled_efield = resampled_efield.T[:-1].T
         station.set_trace(resampled_efield, sampling_rate)
 
     def end(self):


### PR DESCRIPTION
-Prevents time traces from having an uneven number of samples.
-Makes the get_trace and get_frequency_spectrum functions set the _time_trace or the _frequency_spectrum to None if it is out of date, since they are not used and only make files larger.