### PR TITLE
Eventbrowser voltage from rec trace

### DIFF
--- a/NuRadioReco/eventbrowser/apps/traces.py
+++ b/NuRadioReco/eventbrowser/apps/traces.py
@@ -466,7 +466,7 @@ def update_time_traces(evt_counter, filename, dropdown_traces, dropdown_info, st
         channel_ids = []
         for channel in station.iter_channels():
             channel_ids.append(channel.get_id())
-        for i_trace, trace in enumerate(trace_utilities.get_channel_voltage_from_efield(station, channel_ids, det, station.get_parameter(stnp.zenith), station.get_parameter(stnp.azimuth), antenna_pattern_provider)):
+        for i_trace, trace in enumerate(trace_utilities.get_channel_voltage_from_efield(station, channel_ids, det, station.get_parameter(stnp.zenith), station.get_parameter(stnp.azimuth), antenna_pattern_provider, cosmic_ray_mode=station.is_cosmic_ray())):
                 fig.append_trace(go.Scatter(
                     x=station.get_times()/units.ns,
                     y=fft.freq2time(trace)/units.mV,

--- a/NuRadioReco/eventbrowser/apps/traces.py
+++ b/NuRadioReco/eventbrowser/apps/traces.py
@@ -11,14 +11,21 @@ from app import app
 import dataprovider
 from NuRadioReco.utilities import units
 from NuRadioReco.utilities import templates
+from NuRadioReco.utilities import trace_utilities
+from NuRadioReco.utilities import fft
+from NuRadioReco.detector import detector
 from NuRadioReco.framework.parameters import stationParameters as stnp
 from NuRadioReco.framework.parameters import channelParameters as chp
+import NuRadioReco.detector.antennapattern
 import numpy as np
 import logging
+
 logger = logging.getLogger('traces')
 
 provider = dataprovider.DataProvider()
 template_provider = templates.Templates()
+det = detector.Detector()
+antenna_pattern_provider = NuRadioReco.detector.antennapattern.AntennaPatternProvider()
 
 layout = html.Div([
     html.Div(id='trigger-trace', style={'display': 'none'}),
@@ -61,7 +68,8 @@ layout = html.Div([
                                 {'label': 'calibrated trace', 'value': 'trace'},
                                 {'label': 'cosmic-ray template', 'value': 'crtemplate'},
                                 {'label': 'neutrino template', 'value': 'nutemplate'},
-                                {'label': 'envelope', 'value': 'envelope'}
+                                {'label': 'envelope', 'value': 'envelope'},
+                                {'label': 'from rec. E-field', 'value': 'efield'}
                             ],
                             multi=True,
                             value=["trace"]
@@ -305,10 +313,10 @@ def update_time_traces(evt_counter, filename, dropdown_traces, dropdown_info, st
                               shared_xaxes=True, shared_yaxes=False,
                               vertical_spacing=0.01)
     ymax = 0
+    for i, channel in enumerate(station.iter_channels()):
+        trace = channel.get_trace() / units.mV
+        ymax = max(ymax, np.max(np.abs(trace)))
     if 'trace' in dropdown_traces:
-        for i, channel in enumerate(station.iter_channels()):
-            trace = channel.get_trace() / units.mV
-            ymax = max(ymax, np.max(np.abs(trace)))
         for i, channel in enumerate(station.iter_channels()):
             tt = channel.get_times() / units.ns
             trace = channel.get_trace() / units.mV
@@ -453,6 +461,30 @@ def update_time_traces(evt_counter, filename, dropdown_traces, dropdown_info, st
                     textposition='top center'
                 ),
             i + 1, 1)
+    if 'efield' in dropdown_traces:
+        det.update(station.get_station_time())
+        channel_ids = []
+        for channel in station.iter_channels():
+            channel_ids.append(channel.get_id())
+        for i_trace, trace in enumerate(trace_utilities.get_channel_voltage_from_efield(station, channel_ids, det, station.get_parameter(stnp.zenith), station.get_parameter(stnp.azimuth), antenna_pattern_provider)):
+                fig.append_trace(go.Scatter(
+                    x=station.get_times()/units.ns,
+                    y=fft.freq2time(trace)/units.mV,
+                    line=dict(
+                        dash='solid',
+                        color=colors[i_trace%len(colors)]
+                    ),
+                    opacity=.5
+                ), i_trace+1, 1)
+                fig.append_trace(go.Scatter(
+                    x=station.get_frequencies()/units.MHz,
+                    y=np.abs(trace)/units.mV,
+                    line=dict(
+                        dash='solid',
+                        color=colors[i_trace%len(colors)]
+                    ),
+                    opacity=.5
+                ), i_trace + 1, 2)
     fig['layout']['xaxis1'].update(title='time [ns]')
     fig['layout']['yaxis1'].update(title='voltage [mV]')
     for i, channel in enumerate(station.iter_channels()):
@@ -460,12 +492,11 @@ def update_time_traces(evt_counter, filename, dropdown_traces, dropdown_info, st
 
         tt = channel.get_times()
         dt = tt[1] - tt[0]
-        trace = channel.get_trace()
-        ff = np.fft.rfftfreq(len(tt), dt)
-        spec = np.abs(np.fft.rfft(trace, norm='ortho'))
+        spec = channel.get_frequency_spectrum()
+        ff = channel.get_frequencies()
         fig.append_trace(go.Scatter(
                 x=ff / units.MHz,
-                y=spec / units.mV,
+                y=np.abs(spec) / units.mV,
                 opacity=0.7,
                 marker={
                     'color': colors[i % len(colors)],
@@ -477,7 +508,7 @@ def update_time_traces(evt_counter, filename, dropdown_traces, dropdown_info, st
             fig.append_trace(
                    go.Scatter(
                         x=[0.9 * ff.max() / units.MHz],
-                        y=[0.8 * spec.max() / units.mV],
+                        y=[0.8 * np.abs(spec).max() / units.mV],
                         mode='text',
                         text=['max L1 = {:.2f}'.format(get_L1(spec))],
                         textposition='top center'

--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -20,7 +20,7 @@ class BaseStation(NuRadioReco.framework.base_trace.BaseTrace):
         self._station_time = None
         self._triggers = {}
         self._triggered = False
-        self._is_neutrino = True
+        self._particle_type = 'nu'
 
     def __setitem__(self, key, value):
         self.set_parameter(key, value)
@@ -135,13 +135,22 @@ class BaseStation(NuRadioReco.framework.base_trace.BaseTrace):
         self.set_trigger(trigger)
 
     def is_neutrino(self):
-        return self._is_neutrino
+        return self._particle_type == 'nu'
         
     def is_cosmic_ray(self):
-        return not self._is_neutrino
+        return self._particle_type == 'cr'
         
-    def set_is_neutrino(self, is_neutrino):
-        self._is_neutrino = is_neutrino
+    def set_is_neutrino(self):
+        """
+        set station type to neutrino
+        """
+        self._is_neutrino = 'nu'
+    
+    def set_is_cosmic_ray(self):
+        """
+        set station type to cosmic rays (relevant e.g. for refraction into the snow)
+        """
+        self._is_neutrino = 'cr'
 
 
     def serialize(self, mode):
@@ -156,7 +165,7 @@ class BaseStation(NuRadioReco.framework.base_trace.BaseTrace):
                 '_parameter_covariances': self._parameter_covariances,
                 '_station_id': self._station_id,
                 '_station_time': self._station_time,
-                '_is_neutrino': self._is_neutrino,
+                '_particle_type': self._particle_type,
                 'triggers': trigger_pkls,
                 '_triggered': self._triggered,
                 'base_trace': base_trace_pkl}
@@ -174,4 +183,4 @@ class BaseStation(NuRadioReco.framework.base_trace.BaseTrace):
         self._parameter_covariances = data['_parameter_covariances']
         self._station_id = data['_station_id']
         self._station_time = data['_station_time']
-        self._is_neutrino = data['_is_neutrino']
+        self._particle_type = data['_particle_type']

--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -134,13 +134,13 @@ class BaseStation(NuRadioReco.framework.base_trace.BaseTrace):
         trigger.set_triggered(triggered)
         self.set_trigger(trigger)
 
-    def is_neutrino():
+    def is_neutrino(self):
         return self._is_neutrino
         
-    def is_cosmic_ray():
+    def is_cosmic_ray(self):
         return not self._is_neutrino
         
-    def set_is_neutrino(is_neutrino):
+    def set_is_neutrino(self, is_neutrino):
         self._is_neutrino = is_neutrino
 
 

--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -20,6 +20,7 @@ class BaseStation(NuRadioReco.framework.base_trace.BaseTrace):
         self._station_time = None
         self._triggers = {}
         self._triggered = False
+        self._is_neutrino = True
 
     def __setitem__(self, key, value):
         self.set_parameter(key, value)
@@ -133,6 +134,15 @@ class BaseStation(NuRadioReco.framework.base_trace.BaseTrace):
         trigger.set_triggered(triggered)
         self.set_trigger(trigger)
 
+    def is_neutrino():
+        return self._is_neutrino
+        
+    def is_cosmic_ray():
+        return not self._is_neutrino
+        
+    def set_is_neutrino(is_neutrino):
+        self._is_neutrino = is_neutrino
+
 
     def serialize(self, mode):
         if(mode == 'micro'):
@@ -146,6 +156,7 @@ class BaseStation(NuRadioReco.framework.base_trace.BaseTrace):
                 '_parameter_covariances': self._parameter_covariances,
                 '_station_id': self._station_id,
                 '_station_time': self._station_time,
+                '_is_neutrino': self._is_neutrino,
                 'triggers': trigger_pkls,
                 '_triggered': self._triggered,
                 'base_trace': base_trace_pkl}
@@ -163,3 +174,4 @@ class BaseStation(NuRadioReco.framework.base_trace.BaseTrace):
         self._parameter_covariances = data['_parameter_covariances']
         self._station_id = data['_station_id']
         self._station_time = data['_station_time']
+        self._is_neutrino = data['_is_neutrino']

--- a/NuRadioReco/modules/cosmicRayIdentifier.py
+++ b/NuRadioReco/modules/cosmicRayIdentifier.py
@@ -1,0 +1,34 @@
+import logging
+logger = logging.getLogger('cosmicRayIdentifier')
+
+
+class cosmicRayIdentifier:
+    """
+    Use this module to distinguish cosmic ray events from neutrino events
+    """
+
+    def begin(self):
+        pass
+    
+    def run(self, event, station, mode):
+        """
+        Decides if event recorded by station should be treated as a cosmic ray
+        event and sets the is_neutrino flag accordingly
+        
+        Parameters
+        ---------------------
+        mode: string
+            specifies which criteria the decision to flag the event as cosmic ray
+            should be based on. Currently only supports 'forced', which automatically
+            flags the event as cosmic ray. Add new modes to use different criteria
+        """
+        
+        if mode == 'forced':
+            if station.is_cosmic_ray():
+                logger.warning('Event is already flagged as cosmic ray.')
+            station.set_is_neutrino(False)
+        else:
+            raise ValueError('Unsupported mode {}'.format(mode))
+            
+        
+    

--- a/NuRadioReco/modules/io/coreas/coreas.py
+++ b/NuRadioReco/modules/io/coreas/coreas.py
@@ -98,6 +98,7 @@ def make_sim_station(station_id, corsika, observer, weight=None):
     sim_station.set_parameter(stnp.cr_energy, energy)
     sim_station.set_magnetic_field_vector(magnetic_field_vector)
     sim_station.set_parameter(stnp.cr_energy_em, corsika["highlevel"].attrs["Eem"])
+    sim_station.set_is_neutrino(False)
 
     sim_station.set_simulation_weight(weight)
     return sim_station

--- a/NuRadioReco/modules/voltageToAnalyticEfieldConverter.py
+++ b/NuRadioReco/modules/voltageToAnalyticEfieldConverter.py
@@ -277,7 +277,7 @@ class voltageToAnalyticEfieldConverter:
     def run(self, evt, station, det, debug=False, debug_plotpath=None,
             use_channels=[0, 1, 2, 3],
             bandpass=[100 * units.MHz, 500 * units.MHz],
-            useMCdirection=False):
+            useMCdirection=False, cosmic_ray_mode=False):
         """
         run method. This function is executed for each event
 
@@ -296,6 +296,8 @@ class voltageToAnalyticEfieldConverter:
         bandpass: [float, float]
             the lower and upper frequecy for which the analytic pulse is calculated.
             A butterworth filter of 10th order and a rectangular filter is applied.
+        cosmic_ray_mode: boolean
+            If set to true, the signal is assumed to be from an air shower and the refraction at the air/ice boundary is taken into account
         """
         self.__counter += 1
         event_time = station.get_station_time()
@@ -313,7 +315,7 @@ class voltageToAnalyticEfieldConverter:
 
         efield_antenna_factor, V, V_timedomain = get_array_of_channels(station, use_channels,
                                                                        det, zenith, azimuth, self.antenna_provider,
-                                                                       time_domain=True)
+                                                                       time_domain=True, cosmic_ray_mode=cosmic_ray_mode)
         sampling_rate = station.get_channel(0).get_sampling_rate()
         n_samples_time = V_timedomain.shape[1]
 

--- a/NuRadioReco/modules/voltageToEfieldConverter.py
+++ b/NuRadioReco/modules/voltageToEfieldConverter.py
@@ -16,7 +16,7 @@ from NuRadioReco.framework.parameters import stationParameters as stnp
 from NuRadioReco.framework.parameters import channelParameters as chp
 
 def get_array_of_channels(station, use_channels, det, zenith, azimuth,
-                          antenna_pattern_provider, time_domain=False):
+                          antenna_pattern_provider, time_domain=False, cosmic_ray_mode=False):
     time_shifts = np.zeros(len(use_channels))
     t_cables = np.zeros(len(use_channels))
     t_geos = np.zeros(len(use_channels))
@@ -83,7 +83,7 @@ def get_array_of_channels(station, use_channels, det, zenith, azimuth,
     for iCh, trace in enumerate(traces):
         V[iCh] = trace.get_frequency_spectrum()
 
-    efield_antenna_factor = trace_utilities.get_efield_antenna_factor(station, frequencies, use_channels, det, zenith, azimuth, antenna_pattern_provider)
+    efield_antenna_factor = trace_utilities.get_efield_antenna_factor(station, frequencies, use_channels, det, zenith, azimuth, antenna_pattern_provider, cosmic_ray_mode)
     
     if(debug_cut):
         plt.show()
@@ -119,7 +119,7 @@ class voltageToEfieldConverter:
         self.antenna_provider = antennapattern.AntennaPatternProvider()
         pass
 
-    def run(self, evt, station, det, debug=False, debug_plotpath=None, use_channels=[0, 1, 2, 3]):
+    def run(self, evt, station, det, debug=False, debug_plotpath=None, use_channels=[0, 1, 2, 3], cosmic_ray_mode=False):
         """
         run method. This function is executed for each event
 
@@ -135,6 +135,8 @@ class voltageToEfieldConverter:
             be save into the `debug_plotpath` directory
         use_channels: array of ints
             the channel ids to use for the electric field reconstruction
+        cosmic_ray_mode: boolean
+            If set to true, the signal is assumed to be from an air shower and the refraction at the air/ice boundary is taken into account
         """
         event_time = station.get_station_time()
         station_id = station.get_id()
@@ -150,7 +152,7 @@ class voltageToEfieldConverter:
             sim_present = False
 
 
-        efield_antenna_factor, V = get_array_of_channels(station, use_channels, det, zenith, azimuth, self.antenna_provider)
+        efield_antenna_factor, V = get_array_of_channels(station, use_channels, det, zenith, azimuth, self.antenna_provider, cosmic_ray_mode)
         n_frequencies = len(V[0])
         denom = (efield_antenna_factor[0][0] * efield_antenna_factor[1][1] - efield_antenna_factor[0][1] * efield_antenna_factor[1][0])
         mask = np.abs(denom) != 0

--- a/NuRadioReco/utilities/trace_utilities.py
+++ b/NuRadioReco/utilities/trace_utilities.py
@@ -62,7 +62,7 @@ def get_efield_antenna_factor(station, frequencies, channels, detector, zenith, 
         efield_antenna_factor[iCh] = np.array([VEL['theta'] * t_theta, VEL['phi'] * t_phi])
     return efield_antenna_factor
     
-def get_channel_voltage_from_efield(station, channels, detector, zenith, azimuth, antenna_pattern_provider, i_sim_channel=0, return_spectrum=True):
+def get_channel_voltage_from_efield(station, channels, detector, zenith, azimuth, antenna_pattern_provider, return_spectrum=True):
     """
     Returns the voltage traces that would result in the channels from the station's E-field. 
     

--- a/NuRadioReco/utilities/trace_utilities.py
+++ b/NuRadioReco/utilities/trace_utilities.py
@@ -1,0 +1,61 @@
+from NuRadioReco.utilities import units
+import numpy as np
+from NuRadioReco.framework.parameters import stationParameters as stnp
+from NuRadioReco.framework.parameters import channelParameters as chp
+from NuRadioReco.utilities import ice
+from NuRadioReco.utilities import geometryUtilities as geo_utl
+import logging
+logger = logging.getLogger('trace_utilities')
+
+
+
+
+def get_efield_antenna_factor(station, frequencies, channels, detector, zenith, azimuth, antenna_pattern_provider):
+    """
+    Returns the antenna response to a radio signal coming from a specific direction
+    
+    Parameters
+    ---------------
+    station: Station
+    frequencies: array of complex
+        frequencies of the radio signal for which the antenna response is needed
+    channels: array of int
+        IDs of the channels
+    detector: Detector
+    zenith, azimuth: float, float
+        incoming direction of the signal. Note that refraction and reflection at the ice/air boundary are taken into account
+    antenna_pattern_provider: AntennaPatternProvider
+    -----------------
+    """
+    n_ice = ice.get_refractive_index(-0.01, detector.get_site(station.get_id()))
+    efield_antenna_factor = np.zeros((len(channels), 2, len(frequencies)), dtype=np.complex)  # from antenna model in e_theta, e_phi
+    
+    for iCh, channel in enumerate(station.iter_channels(channels)):
+        zenith_antenna = zenith
+        t_theta = 1.
+        t_phi = 1.
+        # first check case if signal comes from above
+        if(zenith <= 0.5 * np.pi):
+            # is antenna below surface?
+            position = detector.get_relative_position(station.get_id(), channel.get_id())
+            if(position[2] <= 0):
+                zenith_antenna = geo_utl.get_fresnel_angle(zenith, n_ice, 1)
+                t_theta = geo_utl.get_fresnel_t_p(zenith, n_ice, 1)
+                t_phi = geo_utl.get_fresnel_t_s(zenith, n_ice, 1)
+                logger.info("channel {:d}: electric field is refracted into the firn. theta {:.0f} -> {:.0f}. Transmission coefficient p (eTheta) {:.2f} s (ePhi) {:.2f}".format(iCh, zenith / units.deg, zenith_antenna / units.deg, t_theta, t_phi))
+        else:
+            # now the signal is coming from below, do we have an antenna above the surface?
+            position = det.get_relative_position(station_id, channel.get_id())
+            if(position[2] > 0):
+                zenith_antenna = geo_utl.get_fresnel_angle(zenith, 1., n_ice)
+        if(zenith_antenna is None):
+            logger.warning("fresnel reflection at air-firn boundary leads to unphysical results, no reconstruction possible")
+            return None
+
+        logger.debug("angles: zenith {0:.0f}, zenith antenna {1:.0f}, azimuth {2:.0f}".format(np.rad2deg(zenith), np.rad2deg(zenith_antenna), np.rad2deg(azimuth)))
+        antenna_model = detector.get_antenna_model(station.get_id(), channel.get_id(), zenith_antenna)
+        antenna_pattern = antenna_pattern_provider.load_antenna_pattern(antenna_model)
+        ori = detector.get_antanna_orientation(station.get_id(), channel.get_id())
+        VEL = antenna_pattern.get_antenna_response_vectorized(frequencies, zenith_antenna, azimuth, *ori)
+        efield_antenna_factor[iCh] = np.array([VEL['theta'] * t_theta, VEL['phi'] * t_phi])
+    return efield_antenna_factor


### PR DESCRIPTION
Changes 2 things:
1. adds 2 utility functions. One returns the antenna response for a give incoming direction. This was already part of the voltageToEfieldConverter's  get_array_of_channels function but was moved into its own utility function for easier use. The other returns the voltage traces that would result from the reconstructed electric field.
2. adds the option to also show the voltage traces that would result from the electric field in the voltage trace plots of the event browser.