### PR TITLE
Coreas selection

### DIFF
--- a/NuRadioReco/modules/channelTemplateCorrelation.py
+++ b/NuRadioReco/modules/channelTemplateCorrelation.py
@@ -12,6 +12,7 @@ from NuRadioReco.framework.parameters import channelParameters as chp
 import logging
 logger = logging.getLogger('channelTemplateCorrelation')
 
+import matplotlib.pyplot as plt
 
 class channelTemplateCorrelation:
     """
@@ -67,15 +68,16 @@ class channelTemplateCorrelation:
                 ref_template = self.__templates.get_nu_ref_template(station_id)
                 ref_str = 'nu'
         else:
-            logger.info("Using average of correlation over many templates")
+            logger.debug("Using average of correlation over many templates")
             if cosmic_ray:
-                ref_templates = self.__templates.get_set_of_cr_templates(station_id, n=n_templates)
+                ref_templates = self.__templates.get_set_of_cr_templates_full(station_id, n=n_templates)
                 ref_str = 'cr'
             else:
-                ref_templates = self.__templates.get_set_of_nu_templates(station_id, n=n_templates)
+                ref_templates = self.__templates.get_set_of_nu_templates_full(station_id, n=n_templates)
                 ref_str = 'nu'
 
         xcorrs = []
+        xcorrs_max = []
 
         for iCh, channel in enumerate(station.iter_channels()):
             channel_id = channel.get_id()
@@ -121,14 +123,16 @@ class channelTemplateCorrelation:
 
             else:
                 template_key = []
+
                 for key in ref_templates.keys():
 
                     ref_template = ref_templates[key][channel.get_id()]
                     ref_template_resampled = self.match_sampling(ref_template, resampling_factor)
 
+
                     xcorr_trace = hp.get_normalized_xcorr(trace, ref_template_resampled)
                     xcorrpos = np.argmax(np.abs(xcorr_trace))
-                    xcorr = xcorr_trace[xcorrpos]
+                    xcorr = np.abs(xcorr_trace[xcorrpos])
 
                     xcorrpos_ch.append(xcorrpos)
                     xcorrs_ch.append(xcorr)
@@ -136,30 +140,49 @@ class channelTemplateCorrelation:
 
                 xcorrelations['{}_ref_xcorr'.format(ref_str)] = np.abs(xcorrs_ch).mean()
                 xcorrelations['{}_ref_xcorr_all'.format(ref_str)] = np.abs(xcorrs_ch)
-                xcorrelations['{}_ref_xcorr_max'.format(ref_str)] = xcorrs_ch[np.argmax(np.abs(xcorrs_ch))]
+                xcorrelations['{}_ref_xcorr_max'.format(ref_str)] = np.abs(xcorrs_ch[np.argmax(np.abs(xcorrs_ch))])
                 xcorrelations['{}_ref_xcorr_time'.format(ref_str)] = np.mean(xcorrpos_ch[np.argmax(np.abs(xcorrs_ch))]) * dt
                 xcorrelations['{}_ref_xcorr_template'.format(ref_str)] = template_key[np.argmax(np.abs(xcorrs_ch))]
+
                 logger.debug("average xcorr over all templates {:.2f} +- {:.2f}, \
                     best template is {} at position {:.2f}".format(np.abs(xcorrs_ch).mean(),
                     np.abs(xcorrs_ch).std(),
                     xcorrelations['{}_ref_xcorr_template'.format(ref_str)],
                     xcorrelations['{}_ref_xcorr_time'.format(ref_str)]))
 
-                xcorrs.append(np.abs(xcorrs_ch).mean())
+                xcorrs.append(np.nanmean(np.abs(xcorrs_ch)))
+                xcorrs_max.append(np.nanmax(np.abs(xcorrs_ch)))
 
+            if self.__debug:
+                print "per channel", len(xcorrs_ch)
+                plt.hist(xcorrs_ch,range=(0,1),bins=50)
+                plt.show()
+                print xcorrs
             #Writing information to channel
             if cosmic_ray:
                 channel[chp.cr_xcorrelations] = xcorrelations
             else:
                 channel[chp.nu_xcorrelations] = xcorrelations
 
+
         xcorrs = np.array(xcorrs)
-        xcorrelations_station = {}
-        xcorrelations_station['number_of_templates'] = n_templates
-        xcorrelations_station['{}_max_xcorr'.format(ref_str)] = np.abs(xcorrs).max()
-        ref_mask = np.array([channel.get_id() in channels_to_use for channel in station.iter_channels()])
-        xcorrelations_station['{0}_max_xcorr_{0}channels'.format(ref_str)] = np.abs(xcorrs[ref_mask]).max()
-        xcorrelations_station['{0}_avg_xcorr_{0}channels'.format(ref_str)] = np.abs(xcorrs[ref_mask]).mean()
+        xcorrs_max = np.array(xcorrs_max)
+
+        if n_templates == 1:
+
+            xcorrelations_station = {}
+            xcorrelations_station['number_of_templates'] = n_templates
+            xcorrelations_station['{}_max_xcorr'.format(ref_str)] = np.abs(xcorrs).max()
+            ref_mask = np.array([channel.get_id() in channels_to_use for channel in station.iter_channels()])
+            xcorrelations_station['{0}_max_xcorr_{0}channels'.format(ref_str)] = np.abs(xcorrs[ref_mask]).max()
+            xcorrelations_station['{0}_avg_xcorr_{0}channels'.format(ref_str)] = np.abs(xcorrs[ref_mask]).mean()
+        else:
+            xcorrelations_station = {}
+            xcorrelations_station['number_of_templates'] = n_templates
+            xcorrelations_station['{}_max_xcorr'.format(ref_str)] = xcorrs_max.max()
+            ref_mask = np.array([channel.get_id() in channels_to_use for channel in station.iter_channels()])
+            xcorrelations_station['{0}_max_xcorr_{0}channels'.format(ref_str)] = xcorrs_max[ref_mask].max()
+            xcorrelations_station['{0}_avg_xcorr_{0}channels'.format(ref_str)] = xcorrs[ref_mask].mean()
 
         # calculate average xcorr in parallel channels
         parallel_channels = det.get_parallel_channels(station_id)

--- a/NuRadioReco/modules/efieldToVoltageConverter.py
+++ b/NuRadioReco/modules/efieldToVoltageConverter.py
@@ -189,7 +189,10 @@ class efieldToVoltageConverter:
                 azimuth = electric_field[efp.azimuth]
 
                 # get antenna pattern for current channel
-                VEL = trace_utilities.get_efield_antenna_factor(sim_station, ff, [channel_id], det, zenith, azimuth, self.antenna_provider)[0]
+                try:
+                    VEL = trace_utilities.get_efield_antenna_factor(sim_station, ff, [channel_id], det, zenith, azimuth, self.antenna_provider)[0]
+                except:
+                    logger.warning("efieldToVoltageConverter cannot continue with unphysical values, VEL is None")
 
                 # Apply antenna response to electric field
                 voltage_fft = np.sum(VEL * np.array([efield_fft[1], efield_fft[2]]), axis=0)

--- a/NuRadioReco/modules/io/coreas/simulationSelector.py
+++ b/NuRadioReco/modules/io/coreas/simulationSelector.py
@@ -81,13 +81,11 @@ class simulationSelector:
             noise_std = np.std(noise_region)
 
             noise += n_std * noise_std
-
-            mask =  np.where(np.abs(fft[max_pol]) > noise)
-            max_freq = np.max(freq[mask])
-            if max_freq > np.min(np.array(frequency_window)):
+            
+            mask = (freq >= frequency_window.min())  & (freq <= frequency_window.max())
+            if(np.any(fft[:, mask] > noise)):
                 selected_sim = True
                 break
-
 
         self.__t += time.time() - t
         return selected_sim

--- a/NuRadioReco/modules/io/coreas/simulationSelector.py
+++ b/NuRadioReco/modules/io/coreas/simulationSelector.py
@@ -1,0 +1,31 @@
+import numpy as np
+import logging
+
+logger = logging.getLogger('simulationSelector')
+
+class simulationSelector:
+    '''
+    Module that let's you select CoREAS simulations
+    based on certain criteria, e.g. signal in a relevant band
+    certain arrival directions, energies, etc.
+    '''
+
+    def __init__(self):
+        self.__t = 0
+        self.begin()
+
+    def begin(self, debug=False):
+        pass
+
+    def run(self, evt):
+        t = time.time()
+
+
+        self.__t += time.time() - t
+
+    def end(self):
+        from datetime import timedelta
+        logger.setLevel(logging.INFO)
+        dt = timedelta(seconds=self.__t)
+        logger.info("total time used by this module is {}".format(dt))
+        return dt

--- a/NuRadioReco/modules/io/coreas/simulationSelector.py
+++ b/NuRadioReco/modules/io/coreas/simulationSelector.py
@@ -22,12 +22,12 @@ class simulationSelector:
     def begin(self, debug=False):
         pass
 
-    def run(self, evt, sim_station, det, frequency_window = [100*units.MHz,500*units.MHz]):
+    def run(self, evt, sim_station, det, frequency_window = [100*units.MHz,500*units.MHz],n_std = 8):
 
         """
         run method, selects CoREAS simulations that have any signal in
         desired frequency_window.
-        Crude approximation with 7 sigma * noise
+        Crude approximation with n_std sigma * noise
 
         Parameters
         ------------
@@ -37,6 +37,8 @@ class simulationSelector:
         det: Detector
         frequency_window: list
             [lower, upper] frequencies that will be used for analysis
+        n_std: int
+            number of std deviations needed, can make cut stricter, if needed
 
         Returns
         ------------
@@ -60,7 +62,7 @@ class simulationSelector:
                     max_pol = i
                     max_ = np.sum(fft[i])
 
-            # Find a 7 sigma excess above the noise
+            # Find a n_std sigma excess above the noise
             # Seems to be a reasonably well-working number
 
             noise_region = fft[max_pol][np.where(freq > 1.5 * units.GHz)]
@@ -78,11 +80,10 @@ class simulationSelector:
 
             noise_std = np.std(noise_region)
 
-            noise += 7 * noise_std
+            noise += n_std * noise_std
 
             mask =  np.where(np.abs(fft[max_pol]) > noise)
             max_freq = np.max(freq[mask])
-
             if max_freq > np.min(np.array(frequency_window)):
                 selected_sim = True
                 break


### PR DESCRIPTION
I have added a module that removes CoREAS sims at the first step after the read in. This avoids all simulations that don't have signal in the interesting band, i.e. < 50 MHz only.
Not a fancy module, but it does do the trick most of the time.