### PR TITLE
Energy fluence fix

### DIFF
--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -14,7 +14,6 @@ logger = logging.getLogger('BaseStation')
 class BaseStation():
 
     def __init__(self, station_id):
-        #NuRadioReco.framework.base_trace.BaseTrace.__init__(self)
         self._parameters = {}
         self._ARIANNA_parameters = {}
         self._parameter_covariances = {}

--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -14,7 +14,7 @@ logger = logging.getLogger('BaseStation')
 class BaseStation():
 
     def __init__(self, station_id):
-        NuRadioReco.framework.base_trace.BaseTrace.__init__(self)
+        #NuRadioReco.framework.base_trace.BaseTrace.__init__(self)
         self._parameters = {}
         self._ARIANNA_parameters = {}
         self._parameter_covariances = {}
@@ -197,10 +197,6 @@ class BaseStation():
 
 
     def serialize(self, mode):
-        if(mode == 'micro'):
-            base_trace_pkl = None
-        else:
-            base_trace_pkl = NuRadioReco.framework.base_trace.BaseTrace.serialize(self)
         trigger_pkls = []
         for trigger in self._triggers.values():
             trigger_pkls.append(trigger.serialize())
@@ -222,8 +218,6 @@ class BaseStation():
 
     def deserialize(self, data_pkl):
         data = pickle.loads(data_pkl)
-        if(data['base_trace'] is not None):
-            NuRadioReco.framework.base_trace.BaseTrace.deserialize(self, data['base_trace'])
         if ('triggers' in data):
             self._triggers = NuRadioReco.framework.trigger.deserialize(data['triggers'])
         if ('triggers' in data):

--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -212,8 +212,7 @@ class BaseStation():
                 '_particle_type': self._particle_type,
                 'triggers': trigger_pkls,
                 '_triggered': self._triggered,
-                'electric_fields': efield_pkls,
-                'base_trace': base_trace_pkl}
+                'electric_fields': efield_pkls}
         return pickle.dumps(data, protocol=2)
 
     def deserialize(self, data_pkl):

--- a/NuRadioReco/modules/channelStopFilter.py
+++ b/NuRadioReco/modules/channelStopFilter.py
@@ -35,8 +35,6 @@ class channelStopFilter:
             trace = np.append(np.zeros(np.int(np.round(prepend * sampling_rate))), trace)
             trace = np.append(trace, np.zeros(np.int(np.round(append * sampling_rate))))
             channel.set_trace(trace, sampling_rate)
-        logger.debug("adding {:.0f}ns to station start time of {:.0f}ns".format(-prepend / units.ns, station.get_trace_start_time() / units.ns))
-        station.add_trace_start_time(-prepend)
 
     def end(self):
         pass

--- a/NuRadioReco/modules/electricFieldSignalReconstructor.py
+++ b/NuRadioReco/modules/electricFieldSignalReconstructor.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 from radiotools import helper as hp
 from radiotools import coordinatesystems
 from NuRadioReco.utilities import fft
+from NuRadioReco.utilities import trace_utilities
 import logging
 logger = logging.getLogger('stationSignalReconstructor')
 from NuRadioReco.framework.parameters import stationParameters as stnp
@@ -88,20 +89,12 @@ class electricFieldSignalReconstructor:
             if(self.__noise_window > 0):
                 mask_noise_window[np.int(np.round((-self.__noise_window - 141.) * electric_field.get_sampling_rate())):np.int(np.round(-141. * electric_field.get_sampling_rate()))] = np.ones(np.int(np.round(self.__noise_window * electric_field.get_sampling_rate())), dtype=np.bool)  # the last n bins
 
+            signal_energy_fluence = trace_utilities.get_electric_field_energy_fluence(trace, times, mask_signal_window, mask_noise_window)
             dt = times[1] - times[0]
-            f_signal = np.sum(trace[:, mask_signal_window] ** 2, axis=1) * dt
-            signal_energy_fluence = f_signal
-            logger.debug('f signal {}'.format(f_signal))
-            f_noise = np.zeros_like(f_signal)
             signal_energy_fluence_error = np.zeros(3)
             if(np.sum(mask_noise_window)):
-                f_noise = np.sum(trace[:, mask_noise_window] ** 2, axis=1) * dt
-                logger.debug('f_noise {},  {}/{} = {}'.format(f_noise * np.sum(mask_signal_window) / np.sum(mask_noise_window), np.sum(mask_signal_window), np.sum(mask_noise_window), 1. * np.sum(mask_signal_window) / np.sum(mask_noise_window)))
-                signal_energy_fluence = f_signal - f_noise * np.sum(mask_signal_window) / np.sum(mask_noise_window)
                 RMSNoise = np.sqrt(np.mean(trace[:, mask_noise_window] ** 2, axis=1))
-                signal_energy_fluence_error = (4 * np.abs(signal_energy_fluence) * RMSNoise ** 2 * dt + 2 * (self.__signal_window_pre + self.__signal_window_post) * RMSNoise ** 4 * dt) ** 0.5
-
-            signal_energy_fluence *= self.__conversion_factor_integrated_signal
+                signal_energy_fluence_error = (4 * np.abs(signal_energy_fluence/self.__conversion_factor_integrated_signal) * RMSNoise ** 2 * dt + 2 * (self.__signal_window_pre + self.__signal_window_post) * RMSNoise ** 4 * dt) ** 0.5
             signal_energy_fluence_error *= self.__conversion_factor_integrated_signal
             electric_field.set_parameter(efp.signal_energy_fluence, signal_energy_fluence)
             electric_field.set_parameter_error(efp.signal_energy_fluence, signal_energy_fluence_error)

--- a/NuRadioReco/modules/voltageToEfieldConverter.py
+++ b/NuRadioReco/modules/voltageToEfieldConverter.py
@@ -46,7 +46,6 @@ def get_array_of_channels(station, use_channels, det, zenith, azimuth,
     tmax = time_shifts.max()
 #             print('cables ', t_cables)
 #             print('geos', t_geos)
-    station.add_trace_start_time(t_cables.min() + t_geos.max())
 #             print(time_shifts)
     logger.debug("adding relative station time = {:.0f}ns".format((t_cables.min() + t_geos.max()) / units.ns))
     logger.debug("delta t is {:.2f}".format(delta_t / units.ns))

--- a/NuRadioReco/utilities/trace_utilities.py
+++ b/NuRadioReco/utilities/trace_utilities.py
@@ -92,3 +92,16 @@ def get_channel_voltage_from_efield(station, electric_field, channels, detector,
         for i_ch, ch in enumerate(channels):
             voltage_trace[i_ch] = fft.freq2time(np.sum(efield_antenna_factor[i_ch] * np.array([spectrum[1], spectrum[2]]), axis=0))
         return voltage_trace
+        
+def get_electric_field_energy_fluence(electric_field_trace, times, signal_window_mask = None, noise_window_mask = None):
+    conversion_factor_integrated_signal = 2.65441729 * 1e-3 / units.s * units.joule  # to convert V**2/m**2 * s -> J/m**2 -> eV/m**2
+    if signal_window_mask is None:
+        f_signal = np.sum(electric_field_trace ** 2, axis=1)
+    else:
+        f_signal = np.sum(electric_field_trace[:, signal_window_mask] ** 2, axis=1)
+    dt = times[1] - times[0]
+    if noise_window_mask is not None:
+        f_noise = np.sum(electric_field_trace[:, noise_window_mask] ** 2, axis=1)
+        f_signal -= f_noise * np.sum(signal_window_mask) / np.sum(noise_window_mask)
+        
+    return f_signal * dt * conversion_factor_integrated_signal


### PR DESCRIPTION
- removes calls to base_trace functions from base_station
- adds utility function to calculate energy fluence of efield trace
- makes voltageToAnalyticEfieldConverter and electricFieldSignalReconstructor use this function to calculate energy fluence
@cg-laser I think it would be better if the conversion_factor_integrated_signal was expressed in constants and units instead of just some number. I just could'nt figure out where exactly the 2.65441729 * 1e-3 come from, so if you remember, could you fix this?