### PR TITLE
Typo fixes

### DIFF
--- a/NuRadioReco/modules/channelTemplateCorrelation.py
+++ b/NuRadioReco/modules/channelTemplateCorrelation.py
@@ -143,7 +143,7 @@ class channelTemplateCorrelation:
                     plt.figure()
                     plt.hist(xcorrs_ch,range=(0,1),bins=50)
                     plt.axvline(np.mean(np.abs(xcorrs_ch)))
-                    plt.axvline(np.max(np.abs(xcorrs_ch)))s
+                    plt.axvline(np.max(np.abs(xcorrs_ch)))
                     print(np.mean(np.abs(xcorrs_ch)), np.max(np.abs(xcorrs_ch)),
                             channel[chp.maximum_amplitude]/units.mV)
 

--- a/NuRadioReco/modules/io/coreas/simulationSelector.py
+++ b/NuRadioReco/modules/io/coreas/simulationSelector.py
@@ -81,8 +81,9 @@ class simulationSelector:
             noise_std = np.std(noise_region)
 
             noise += n_std * noise_std
-            
-            mask = (freq >= frequency_window.min())  & (freq <= frequency_window.max())
+
+            mask = np.array((freq >= np.min(frequency_window))  & (freq <= np.max(frequency_window)))
+
             if(np.any(fft[:, mask] > noise)):
                 selected_sim = True
                 break


### PR DESCRIPTION
Somewhere in previous commits, there were a couple of typos introduced. 
Also, we should use the method that works for both lists and arrays. 