### PR TITLE
Parameter compatibility

### DIFF
--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -3,6 +3,7 @@ import NuRadioReco.framework.base_trace
 import NuRadioReco.framework.trigger
 import NuRadioReco.framework.electric_field
 import NuRadioReco.framework.parameters as parameters
+import NuRadioReco.framework.parameter_serialization
 try:
     import cPickle as pickle
 except ImportError:
@@ -203,7 +204,7 @@ class BaseStation():
         if(mode != 'micro'):
             for efield in self.get_electric_fields():
                 efield_pkls.append(efield.serialize(self))
-        data = {'_parameters': self._parameters,
+        data = {'_parameters': NuRadioReco.framework.parameter_serialization.serialize(self._parameters),
                 '_parameter_covariances': self._parameter_covariances,
                 '_ARIANNA_parameters': self._ARIANNA_parameters,
                 '_station_id': self._station_id,
@@ -224,7 +225,7 @@ class BaseStation():
             efield = NuRadioReco.framework.electric_field.ElectricField([])
             efield.deserialize(electric_field)
             self.add_electric_field(efield)
-        self._parameters = data['_parameters']
+        self._parameters = NuRadioReco.framework.parameter_serialization.deserialize(data['_parameters'], parameters.stationParameters)
         self._parameter_covariances = data['_parameter_covariances']
         if('_ARIANNA_parameters') in data:
             self._ARIANNA_parameters = data['_ARIANNA_parameters']

--- a/NuRadioReco/framework/channel.py
+++ b/NuRadioReco/framework/channel.py
@@ -52,7 +52,7 @@ class Channel(NuRadioReco.framework.base_trace.BaseTrace):
             base_trace_pkl = None
         else:
             base_trace_pkl = NuRadioReco.framework.base_trace.BaseTrace.serialize(self)
-        data = {'parameters': self._parameters,
+        data = {'parameters': NuRadioReco.framework.parameter_serialization.serialize(self._parameters),
                 'id': self.get_id(),
                 'base_trace': base_trace_pkl}
         if(self.__electric_field is not None):
@@ -64,7 +64,7 @@ class Channel(NuRadioReco.framework.base_trace.BaseTrace):
         data = pickle.loads(data_pkl)
         if(data['base_trace'] is not None):
             NuRadioReco.framework.base_trace.BaseTrace.deserialize(self, data['base_trace'])
-        self._parameters = data['parameters']
+        self._parameters = NuRadioReco.framework.parameter_serialization.deserialize(data['parameters'], parameters.channelParameters)
         self._id = data['id']
         if 'electric_field' in data.keys():
             self.__electric_field = NuRadioReco.framework.base_trace.BaseTrace.deserialize(self, data['electric_field'])

--- a/NuRadioReco/framework/electric_field.py
+++ b/NuRadioReco/framework/electric_field.py
@@ -71,7 +71,7 @@ class ElectricField(NuRadioReco.framework.base_trace.BaseTrace):
             base_trace_pkl = None
         else:
             base_trace_pkl = NuRadioReco.framework.base_trace.BaseTrace.serialize(self)
-        data = {'parameters': self._parameters,
+        data = {'parameters': NuRadioReco.framework.parameter_serialization.serialize(self._parameters),
                 'channel_ids': self._channel_ids,
                 'base_trace': base_trace_pkl}
         return pickle.dumps(data, protocol=2)
@@ -80,5 +80,5 @@ class ElectricField(NuRadioReco.framework.base_trace.BaseTrace):
         data = pickle.loads(data_pkl)
         if(data['base_trace'] is not None):
             NuRadioReco.framework.base_trace.BaseTrace.deserialize(self, data['base_trace'])
-        self._parameters = data['parameters']
+        self._parameters = NuRadioReco.framework.parameter_serialization.deserialize(data['parameters'], parameters.electricFieldParameters)
         self._channel_ids = data['channel_ids']

--- a/NuRadioReco/framework/parameter_serialization.py
+++ b/NuRadioReco/framework/parameter_serialization.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+def serialize(object):
+    reply = {}
+    for entry in object:
+        reply[str(entry)] = object[entry]
+    return reply
+
+def deserialize(object, parameter_enum):
+    reply = {}
+    for entry in parameter_enum:
+        if str(entry) in object:
+            reply[entry] = object[str(entry)]
+    return reply
+    

--- a/NuRadioReco/modules/io/eventWriter.py
+++ b/NuRadioReco/modules/io/eventWriter.py
@@ -13,7 +13,7 @@ def get_header(evt):
     header = {}
     header['stations'] = {}
     for iS, station in enumerate(evt.get_stations()):
-        header['stations'][station.get_id()] = station.get_parameters()
+        header['stations'][station.get_id()] = station.get_parameters().copy()
         if(station.has_sim_station()):
             header['stations'][station.get_id()]['sim_station'] = {}
             header['stations'][station.get_id()]['sim_station'] = station.get_sim_station().get_parameters()


### PR DESCRIPTION
- When an event is serialized, parameter storage keys are converted from enums to strings. When deserializing, the conversion is reversed. This way, files with unknown parameters can still be opened, the parameters will just be ignored.
- Fixes bug that copied the sim_station parameters into the station parameters
- Breaks backward compatibility