### PR TITLE
Event browser mini

### DIFF
--- a/NuRadioReco/eventbrowser/apps/traces.py
+++ b/NuRadioReco/eventbrowser/apps/traces.py
@@ -245,6 +245,8 @@ def update_time_trace(trigger, evt_counter, filename, station_id, juser_id):
     traces = []
     fig = tools.make_subplots(rows=1, cols=1)
     for i, channel in enumerate(station.iter_channels()):
+        if channel.get_trace() is None:
+            continue
         fig.append_trace(go.Scatter(
                 x=channel.get_times() / units.ns,
                 y=channel.get_trace() / units.mV,
@@ -284,6 +286,8 @@ def update_channel_spectrum(trigger, evt_counter, filename, station_id, juser_id
     for i, channel in enumerate(station.iter_channels()):
         tt = channel.get_times()
         dt = tt[1] - tt[0]
+        if channel.get_trace() is None:
+            continue
         trace = channel.get_trace()
         ff = np.fft.rfftfreq(len(tt), dt)
         spec = np.abs(np.fft.rfft(trace, norm='ortho'))
@@ -338,10 +342,13 @@ def update_time_traces(evt_counter, filename, dropdown_traces, dropdown_info, st
     ymax = 0
     for i, channel in enumerate(station.iter_channels()):
         trace = channel.get_trace() / units.mV
-        ymax = max(ymax, np.max(np.abs(trace)))
+        if trace is not None:
+            ymax = max(ymax, np.max(np.abs(trace)))
     if 'trace' in dropdown_traces:
         for i, channel in enumerate(station.iter_channels()):
             tt = channel.get_times() / units.ns
+            if channel.get_trace() is None:
+                continue
             trace = channel.get_trace() / units.mV
             fig.append_trace(go.Scatter(
                     x=tt,
@@ -367,6 +374,8 @@ def update_time_traces(evt_counter, filename, dropdown_traces, dropdown_info, st
                     i + 1, 1)
     if 'envelope' in dropdown_traces:
         for i, channel in enumerate(station.iter_channels()):
+            if channel.get_trace() is None:
+                continue
             trace = channel.get_trace() / units.mV
             from scipy import signal
             yy = np.abs(signal.hilbert(trace))
@@ -399,6 +408,8 @@ def update_time_traces(evt_counter, filename, dropdown_traces, dropdown_info, st
                 ref_template = ref_templates[key][channel.get_id()]
             times = channel.get_times()
             trace = channel.get_trace()
+            if trace is None:
+                continue
             xcorr = channel.get_parameter(chp.cr_xcorrelations)['cr_ref_xcorr']
             xcorrpos = channel.get_parameter(chp.cr_xcorrelations)['cr_ref_xcorr_time']
             dt = times[1] - times[0]
@@ -461,6 +472,8 @@ def update_time_traces(evt_counter, filename, dropdown_traces, dropdown_info, st
         for i, channel in enumerate(station.iter_channels()):
             times = channel.get_times()
             trace = channel.get_trace()
+            if trace is None:
+                continue()
             xcorr = channel.get_parameter(chp.nu_xcorrelations)['nu_ref_xcorr']
             xcorrpos = channel.get_parameter(chp.nu_xcorrelations)['nu_ref_xcorr_time']
             dt = times[1] - times[0]
@@ -542,6 +555,8 @@ def update_time_traces(evt_counter, filename, dropdown_traces, dropdown_info, st
         fig['layout']['yaxis{:d}'.format(i * 2 + 1)].update(range=[-ymax, ymax])
 
         tt = channel.get_times()
+        if tt is None:
+            continue
         dt = tt[1] - tt[0]
         spec = channel.get_frequency_spectrum()
         ff = channel.get_frequencies()
@@ -594,6 +609,8 @@ def update_time_traces2(evt_counter, filename, dropdown_traces, station_id, juse
     if 'trace' in dropdown_traces:
         for i, iCh in enumerate(range(4, min([8, station.get_number_of_channels()]))):
             channel = station.get_channel(iCh)
+            if channel.get_trace() is None:
+                continue
             fig.append_trace(go.Scatter(
                     x=channel.get_times() / units.ns,
                     y=channel.get_trace() / units.mV,
@@ -612,6 +629,8 @@ def update_time_traces2(evt_counter, filename, dropdown_traces, station_id, juse
             channel = station.get_channel(iCh)
             times = channel.get_times()
             trace = channel.get_trace()
+            if trace is None:
+                continue
             xcorr = channel['cr_ref_xcorr']
             xcorrpos = channel['cr_ref_xcorr_time']
             dt = times[1] - times[0]

--- a/NuRadioReco/eventbrowser/apps/traces.py
+++ b/NuRadioReco/eventbrowser/apps/traces.py
@@ -283,10 +283,11 @@ def update_channel_spectrum(trigger, evt_counter, filename, station_id, juser_id
     fig = tools.make_subplots(rows=1, cols=1)
     maxL1 = 0
     maxY = 0
+    ff=np.array([0])
     for i, channel in enumerate(station.iter_channels()):
-        tt = channel.get_times()
-        if tt is None:
+        if channel.get_trace() is None:
             continue
+        tt = channel.get_times()
         dt = tt[1] - tt[0]
         if channel.get_trace() is None:
             continue
@@ -343,8 +344,8 @@ def update_time_traces(evt_counter, filename, dropdown_traces, dropdown_info, st
                               vertical_spacing=0.01)
     ymax = 0
     for i, channel in enumerate(station.iter_channels()):
-        trace = channel.get_trace() / units.mV
-        if trace is not None:
+        if channel.get_trace() is not None:
+            trace = channel.get_trace() / units.mV
             ymax = max(ymax, np.max(np.abs(trace)))
     if 'trace' in dropdown_traces:
         for i, channel in enumerate(station.iter_channels()):
@@ -556,9 +557,9 @@ def update_time_traces(evt_counter, filename, dropdown_traces, dropdown_info, st
     for i, channel in enumerate(station.iter_channels()):
         fig['layout']['yaxis{:d}'.format(i * 2 + 1)].update(range=[-ymax, ymax])
 
-        tt = channel.get_times()
-        if tt is None:
+        if channel.get_trace() is None:
             continue
+        tt = channel.get_times()
         dt = tt[1] - tt[0]
         spec = channel.get_frequency_spectrum()
         ff = channel.get_frequencies()

--- a/NuRadioReco/eventbrowser/apps/traces.py
+++ b/NuRadioReco/eventbrowser/apps/traces.py
@@ -473,7 +473,7 @@ def update_time_traces(evt_counter, filename, dropdown_traces, dropdown_info, st
             times = channel.get_times()
             trace = channel.get_trace()
             if trace is None:
-                continue()
+                continue
             xcorr = channel.get_parameter(chp.nu_xcorrelations)['nu_ref_xcorr']
             xcorrpos = channel.get_parameter(chp.nu_xcorrelations)['nu_ref_xcorr_time']
             dt = times[1] - times[0]

--- a/NuRadioReco/eventbrowser/apps/traces.py
+++ b/NuRadioReco/eventbrowser/apps/traces.py
@@ -285,6 +285,8 @@ def update_channel_spectrum(trigger, evt_counter, filename, station_id, juser_id
     maxY = 0
     for i, channel in enumerate(station.iter_channels()):
         tt = channel.get_times()
+        if tt is None:
+            continue
         dt = tt[1] - tt[0]
         if channel.get_trace() is None:
             continue

--- a/NuRadioReco/eventbrowser/index.py
+++ b/NuRadioReco/eventbrowser/index.py
@@ -155,7 +155,7 @@ def set_event_number(next_evt_click_timestamp, prev_evt_click_timestamp, j_plot_
     if filename is None:
         return 0
     if context.triggered[0]['prop_id'] == 'event-click-coordinator.children':
-        return context.triggered[0]['value']['event_i']
+        return json.loads(context.triggered[0]['value'])['event_i']
     else:
         if context.triggered[0]['prop_id'] != 'btn-next-event.n_clicks_timestamp' and context.triggered[0]['prop_id'] != 'btn-previous-event.n_clicks_timestamp':
             return 0


### PR DESCRIPTION
- Makes eventbroser usable for files saved in mini/micro format by catching exceptions if traces are missing
- Fixes bug that prevented event selection by clicking on points in certain plots