### PR TITLE
No highlevel fix

### DIFF
--- a/NuRadioReco/framework/parameters.py
+++ b/NuRadioReco/framework/parameters.py
@@ -22,7 +22,7 @@ class stationParameters(Enum):
     nu_xcorrelations = 20 #  dict of result of crosscorrelations with nu templates
     station_time = 21
     cr_energy_em = 24  # the electromagnetic shower energy (the cosmic ray energy that ends up in electrons, positrons and gammas)
-    nu_inttype = 25  # interaction type, e.g., cc, nc, tau_em, tau_had    
+    nu_inttype = 25  # interaction type, e.g., cc, nc, tau_em, tau_had
 
 class channelParameters(Enum):
     zenith = 1  # zenith angle of the incoming signal direction
@@ -33,7 +33,7 @@ class channelParameters(Enum):
     P2P_amplitude = 7  # the peak to peak amplitude
     cr_xcorrelations = 8 # dict of result of crosscorrelations with cr templates
     nu_xcorrelations = 9 #  dict of result of crosscorrelations with nu templates
-    
+
 class electricFieldParameters(Enum):
     ray_path_type = 1  # the type of the ray tracing solution ('direct', 'refracted' or 'reflected')
     polarization_angle = 2 # electric field polarization in onsky-coordinates. 0 corresponds to polarization in e_theta, 90deg is polarization in e_phi
@@ -47,7 +47,7 @@ class electricFieldParameters(Enum):
     nu_viewing_angle = 11 # the angle between shower axis and launch vector
     max_amp_antenna = 12  # the maximum amplitude of the signal after convolution with the antenna response pattern, dict with channelid as key
     max_amp_antenna_envelope = 13  # the maximum amplitude of the signal envelope after convolution with the antenna response pattern, dict with channelid as key
-    
+
 class ARIANNAParameters(Enum):  # this class stores parameters specific to the ARIANNA data taking
     seq_start_time = 1  # the start time of a sequence
     seq_stop_time = 2  # the stop time of a sequence

--- a/NuRadioReco/modules/io/coreas/readCoREASStation.py
+++ b/NuRadioReco/modules/io/coreas/readCoREASStation.py
@@ -1,8 +1,11 @@
 import h5py
+import numpy as np
 import NuRadioReco.framework.event
 import NuRadioReco.framework.station
 from NuRadioReco.modules.io.coreas import coreas
 
+import logging
+logger = logging.getLogger('readCoREASStation')
 
 class readCoREASStation:
 
@@ -21,14 +24,20 @@ class readCoREASStation:
         """
         self.__input_files = input_files
         self.__station_id = station_id
-        self.__current_input_file = 0        
+        self.__current_input_file = 0
 
     def run(self, detector):
         for input_file in self.__input_files:
 
             # read in coreas simulation and copy to event
+#             if input_file == "../../data/CR_sims/005548.hdf5":
+#                 continue
             corsika = h5py.File(input_file, "r")
-            weights = coreas.calculate_simulation_weights(corsika["highlevel"].values()[0]["antenna_position"])
+            if corsika["highlevel"].values() == []:
+                logger.warning(" No highlevel quantities in simulated hdf5 files, weights will be one")
+                weights = np.ones(len(corsika['CoREAS']['observers']))
+            else:
+                weights = coreas.calculate_simulation_weights(corsika["highlevel"].values()[0]["antenna_position"])
 
             for i, (name, observer) in enumerate(corsika['CoREAS']['observers'].items()):
                 evt = NuRadioReco.framework.event.Event(corsika['inputs'].attrs['RUNNR'], corsika['inputs'].attrs['EVTNR'])  # create empty event

--- a/NuRadioReco/modules/io/coreas/readCoREASStation.py
+++ b/NuRadioReco/modules/io/coreas/readCoREASStation.py
@@ -29,9 +29,6 @@ class readCoREASStation:
     def run(self, detector):
         for input_file in self.__input_files:
 
-            # read in coreas simulation and copy to event
-#             if input_file == "../../data/CR_sims/005548.hdf5":
-#                 continue
             corsika = h5py.File(input_file, "r")
             if corsika["highlevel"].values() == []:
                 logger.warning(" No highlevel quantities in simulated hdf5 files, weights will be one")

--- a/NuRadioReco/utilities/templates.py
+++ b/NuRadioReco/utilities/templates.py
@@ -25,11 +25,11 @@ class Templates(object):
         self.__nu_templates = {}
         self.__nu_template_set = {}
         self.__path = path
-        
-    
+
+
     def set_template_directory(self, path):
         self.__path = path
-    
+
 
     def __load_cr_template(self, station_id):
         path= os.path.join(self.__path, 'templates_cr_station_{}.pickle'.format(station_id))
@@ -60,8 +60,10 @@ class Templates(object):
             tmpl = self.get_cr_ref_templates(station_id)[4]  # FIXME: hardcoded that channel 4 is a cosmic-ray sensitive channel
         elif station_id == 32:
             tmpl = self.get_cr_ref_templates(station_id)[1]
+        elif station_id == 61:
+            tmpl = self.get_cr_ref_templates(station_id)[5]
         else:
-            logger.error("No hardcoded value for station {}".format(station_id))
+            logger.error("Provided value for CR senistive channel of station {} in templates.py".format(station_id))
             tmpl = None
 
         return tmpl
@@ -112,7 +114,7 @@ class Templates(object):
                         if n_tmpl >= n:
                             break
         return self.__cr_template_set
-    
+
     def get_set_of_nu_templates(self, station_id, n=100):
         """
         gets set of n templates to allow for the calculation of average templates


### PR DESCRIPTION
CoREAS HDF5 files may not have high-level quantities computed. This now allows for the reader to still work but does not compute the weights. Issues a warning. 