### PR TITLE
setting up NuRadioReco for first release on PyPi

### DIFF
--- a/NuRadioReco/__init__.py
+++ b/NuRadioReco/__init__.py
@@ -1,0 +1,3 @@
+""" NuRadioReco: A reconstruction framework for radio neutrino detectors"""
+
+__version__ = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["flit"]
+build-backend = "flit.buildapi"
+
+[tool.flit.metadata]
+module = "NuRadioReco"
+author = "Christian Glaser, Daniel Garcia, Anna Nelles, et al."
+author-email = "work@c-glaser.de"
+home-page = "https://github.com/nu-radio/NuRadioReco"
+classifiers = ["License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"]
+requires = [
+    "tinydb",
+    "tinydb-serialization",
+    "aenum",
+    "astropy",
+    "radiotools >=0.1.0",
+    "h5py",
+    "peakutils",
+]
+
+[tool.flit.metadata.requires-extra]
+doc = ["sphinx"]
+


### PR DESCRIPTION
configuration and publishing is done using flit (https://flit.readthedocs.io/en/latest/index.html)
all dependencies are specified in the config such that NuRadioReco installation is just a `pip install NuRadioReco`

currently setting version to 0.1.0 for testing. 