### PR TITLE
Issues 77 78

### DIFF
--- a/NuRadioReco/eventbrowser/NuRadioViewer
+++ b/NuRadioReco/eventbrowser/NuRadioViewer
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+python "$DIR"/index.py --open-window "$@"

--- a/NuRadioReco/eventbrowser/index.py
+++ b/NuRadioReco/eventbrowser/index.py
@@ -32,7 +32,7 @@ argparser.add_argument('file_location', type=str, help="Path of folder or filena
 parsed_args = argparser.parse_args()
 data_folder = os.path.dirname(parsed_args.file_location)
 if os.path.isfile(parsed_args.file_location):
-    starting_filename = (parsed_args.file_location)
+    starting_filename = [parsed_args.file_location]
 else:
     starting_filename = None
     
@@ -62,8 +62,8 @@ app.layout = html.Div([
                 dcc.Dropdown(id='filename',
                              options=[],
                              multi=True,
-                             className='custom-dropdown',
-                             value=[starting_filename]),
+                             value=starting_filename,
+                             className='custom-dropdown'),
                  html.Div([
                     html.Button('open file', id='btn-open-file', className='btn btn-default')
                     ], className='input-group-btn'),

--- a/NuRadioReco/eventbrowser/index.py
+++ b/NuRadioReco/eventbrowser/index.py
@@ -23,11 +23,13 @@ import argparse
 import dataprovider
 import logging
 import datetime
+import webbrowser
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('index')
 
 argparser = argparse.ArgumentParser(description="Starts the Event Display, which then can be accessed via a webbrowser")
 argparser.add_argument('file_location', type=str, help="Path of folder or filename.")
+argparser.add_argument('--open_window', const=True, default=False, action='store_const', help="Open the event display in a new browser tab on startup")
 
 parsed_args = argparser.parse_args()
 data_folder = os.path.dirname(parsed_args.file_location)
@@ -35,7 +37,8 @@ if os.path.isfile(parsed_args.file_location):
     starting_filename = [parsed_args.file_location]
 else:
     starting_filename = None
-    
+if parsed_args.open_window:
+    webbrowser.open('http://127.0.0.1:8080/')    
 
 app.css.append_css({"external_url": "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"})
 provider = dataprovider.DataProvider()
@@ -405,4 +408,4 @@ def update_event_info_time(event_i, filename, station_id, juser_id):
 if __name__ == '__main__':
     if int(dash.__version__.split('.')[1]) < 39:
         print('WARNING: Dash version 0.39.0 or newer is required, you are running version {}. Please update.'.format(dash.__version__))
-    app.run_server(debug=True, port=8081)
+    app.run_server(debug=False, port=8080)

--- a/NuRadioReco/eventbrowser/index.py
+++ b/NuRadioReco/eventbrowser/index.py
@@ -19,14 +19,23 @@ from apps import cosmic_rays
 from apps.common import get_point_index
 import apps.simulation
 import os
-import sys
+import argparse
 import dataprovider
 import logging
 import datetime
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('index')
 
-data_folder = os.path.dirname(sys.argv[1])
+argparser = argparse.ArgumentParser(description="Starts the Event Display, which then can be accessed via a webbrowser")
+argparser.add_argument('file_location', type=str, help="Path of folder or filename.")
+
+parsed_args = argparser.parse_args()
+data_folder = os.path.dirname(parsed_args.file_location)
+if os.path.isfile(parsed_args.file_location):
+    starting_filename = (parsed_args.file_location)
+else:
+    starting_filename = None
+    
 
 app.css.append_css({"external_url": "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"})
 provider = dataprovider.DataProvider()
@@ -53,7 +62,8 @@ app.layout = html.Div([
                 dcc.Dropdown(id='filename',
                              options=[],
                              multi=True,
-                             className='custom-dropdown'),
+                             className='custom-dropdown',
+                             value=[starting_filename]),
                  html.Div([
                     html.Button('open file', id='btn-open-file', className='btn btn-default')
                     ], className='input-group-btn'),
@@ -156,6 +166,8 @@ def set_event_number(next_evt_click_timestamp, prev_evt_click_timestamp, j_plot_
     if filename is None:
         return 0
     if context.triggered[0]['prop_id'] == 'event-click-coordinator.children':
+        if context.triggered[0]['value'] is None:
+            return 0
         return json.loads(context.triggered[0]['value'])['event_i']
     else:
         if context.triggered[0]['prop_id'] != 'btn-next-event.n_clicks_timestamp' and context.triggered[0]['prop_id'] != 'btn-previous-event.n_clicks_timestamp':
@@ -393,4 +405,4 @@ def update_event_info_time(event_i, filename, station_id, juser_id):
 if __name__ == '__main__':
     if int(dash.__version__.split('.')[1]) < 39:
         print('WARNING: Dash version 0.39.0 or newer is required, you are running version {}. Please update.'.format(dash.__version__))
-    app.run_server(debug=True, port=8080)
+    app.run_server(debug=True, port=8081)

--- a/NuRadioReco/eventbrowser/index.py
+++ b/NuRadioReco/eventbrowser/index.py
@@ -30,6 +30,7 @@ logger = logging.getLogger('index')
 argparser = argparse.ArgumentParser(description="Starts the Event Display, which then can be accessed via a webbrowser")
 argparser.add_argument('file_location', type=str, help="Path of folder or filename.")
 argparser.add_argument('--open_window', const=True, default=False, action='store_const', help="Open the event display in a new browser tab on startup")
+argparser.add_argument('--port', default=8080, help="Specify the port the event display will run on")
 
 parsed_args = argparser.parse_args()
 data_folder = os.path.dirname(parsed_args.file_location)
@@ -38,7 +39,7 @@ if os.path.isfile(parsed_args.file_location):
 else:
     starting_filename = None
 if parsed_args.open_window:
-    webbrowser.open('http://127.0.0.1:8080/')    
+    webbrowser.open('http://127.0.0.1:{}/'.format(parsed_args.port))    
 
 app.css.append_css({"external_url": "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"})
 provider = dataprovider.DataProvider()
@@ -408,4 +409,4 @@ def update_event_info_time(event_i, filename, station_id, juser_id):
 if __name__ == '__main__':
     if int(dash.__version__.split('.')[1]) < 39:
         print('WARNING: Dash version 0.39.0 or newer is required, you are running version {}. Please update.'.format(dash.__version__))
-    app.run_server(debug=False, port=8080)
+    app.run_server(debug=False, port=parsed_args.port)

--- a/NuRadioReco/eventbrowser/index.py
+++ b/NuRadioReco/eventbrowser/index.py
@@ -29,7 +29,7 @@ logger = logging.getLogger('index')
 
 argparser = argparse.ArgumentParser(description="Starts the Event Display, which then can be accessed via a webbrowser")
 argparser.add_argument('file_location', type=str, help="Path of folder or filename.")
-argparser.add_argument('--open_window', const=True, default=False, action='store_const', help="Open the event display in a new browser tab on startup")
+argparser.add_argument('--open-window', const=True, default=False, action='store_const', help="Open the event display in a new browser tab on startup")
 argparser.add_argument('--port', default=8080, help="Specify the port the event display will run on")
 
 parsed_args = argparser.parse_args()


### PR DESCRIPTION
Fixes issues #77 and #78 :

- Both folders and files can be passed via the commandline argument. If a file is specified, it will be opene automatically.
- The option --open_window can be added to the commandline to automatically open a browser window
- Debugging had to be turned off. If debug output is on, the script will be run twice and 2 browser windows will be opened. This seems to be a bug with dash itself.
- The port can be specified in the commandline with the --port command. Useful in case the old port wasn't closed while testing the eventbrowser
- If all channels have a trace_start_time larger than 1000ns, the minimum trace_start_time, rounded down to the next 1000 will be subtracted from the times in the trace plots. The axis label is adjusted to show this.
- This should also fix the issue with the labels, but I don't have files with huge trace_start_times. Can somebody check real quick?

About making the event display an executable: Sounds like a good idea, but I have no idea how to do this.