### PR TITLE
Trigger channel number

### DIFF
--- a/NuRadioReco/framework/trigger.py
+++ b/NuRadioReco/framework/trigger.py
@@ -46,6 +46,7 @@ class Trigger:
         self._triggered = False
         self._trigger_time = None
         self._trigger_type = trigger_type
+        self._triggered_channels = []
 
     def has_triggered(self):
         """
@@ -80,6 +81,13 @@ class Trigger:
     def get_type(self):
         """ get trigger type """
         return self._type
+        
+    def get_triggered_channels(self):
+        """ get IDs of channels that have triggered """
+        return self._triggered_channels
+
+    def set_triggered_channels(self, triggered_channels):
+        self._triggered_channels = triggered_channels
 
     def serialize(self):
         return pickle.dumps(self.__dict__, protocol=2)

--- a/NuRadioReco/modules/trigger/highLowThreshold.py
+++ b/NuRadioReco/modules/trigger/highLowThreshold.py
@@ -148,6 +148,7 @@ class triggerSimulator:
                     break
             else:
                 channel_trace_start_time = station.get_channel(triggered_channels[0]).get_trace_start_time()
+            channels_that_passed_trigger = []
             for channel in station.iter_channels():
                 channel_id = channel.get_id()
                 if triggered_channels is not None and channel_id not in triggered_channels:
@@ -157,6 +158,8 @@ class triggerSimulator:
                 trace = channel.get_trace()
                 triggerd_bins = get_high_low_triggers(trace, threshold_high, threshold_low,
                                                       high_low_window, dt)
+                if True in triggerd_bins:
+                    channels_that_passed_trigger.append(channel)
                 triggerd_bins_channels.append(triggerd_bins)
                 logger.debug("channel {}, len(triggerd_bins) = {}".format(channel_id, len(triggerd_bins)))
 
@@ -175,7 +178,7 @@ class triggerSimulator:
 
         trigger = HighLowTrigger(trigger_name, threshold_high, threshold_low, high_low_window,
                                  coinc_window, channels=triggered_channels,  number_of_coincidences=number_concidences)
-
+        trigger.set_triggered_channels(channels_that_passed_trigger) 
         if not has_triggered:
             trigger.set_triggered(False)
             logger.info("Station has NOT passed trigger")

--- a/NuRadioReco/modules/trigger/highLowThreshold.py
+++ b/NuRadioReco/modules/trigger/highLowThreshold.py
@@ -159,7 +159,7 @@ class triggerSimulator:
                 triggerd_bins = get_high_low_triggers(trace, threshold_high, threshold_low,
                                                       high_low_window, dt)
                 if True in triggerd_bins:
-                    channels_that_passed_trigger.append(channel)
+                    channels_that_passed_trigger.append(channel.get_id())
                 triggerd_bins_channels.append(triggerd_bins)
                 logger.debug("channel {}, len(triggerd_bins) = {}".format(channel_id, len(triggerd_bins)))
 

--- a/NuRadioReco/modules/trigger/multiHighLowThreshold.py
+++ b/NuRadioReco/modules/trigger/multiHighLowThreshold.py
@@ -169,7 +169,7 @@ class triggerSimulator:
                 triggerd_bins = get_multiple_high_low_trigger(trace, threshold_high, threshold_low, n_high_lows, high_low_window, dt)
                 triggerd_bins_channels.append(triggerd_bins)
                 if True in triggerd_bins:
-                    channels_that_passed_trigger.append(channel)
+                    channels_that_passed_trigger.append(channel.get_id())
 
             has_triggered, triggered_bins, triggered_times = get_majority_logic(
                 triggerd_bins_channels, number_concidences, coinc_window, dt)

--- a/NuRadioReco/modules/trigger/multiHighLowThreshold.py
+++ b/NuRadioReco/modules/trigger/multiHighLowThreshold.py
@@ -158,6 +158,7 @@ class triggerSimulator:
                     break
             else:
                 channel_trace_start_time = station.get_channel(triggered_channels[0]).get_trace_start_time()
+            channels_that_passed_trigger = []
             for channel in station.iter_channels():
                 channel_id = channel.get_id()
                 if triggered_channels is not None and channel_id not in triggered_channels:
@@ -167,6 +168,8 @@ class triggerSimulator:
                 trace = channel.get_trace()
                 triggerd_bins = get_multiple_high_low_trigger(trace, threshold_high, threshold_low, n_high_lows, high_low_window, dt)
                 triggerd_bins_channels.append(triggerd_bins)
+                if True in triggerd_bins:
+                    channels_that_passed_trigger.append(channel)
 
             has_triggered, triggered_bins, triggered_times = get_majority_logic(
                 triggerd_bins_channels, number_concidences, coinc_window, dt)
@@ -182,6 +185,7 @@ class triggerSimulator:
 
         trigger = HighLowTrigger(trigger_name, threshold_high, threshold_low, high_low_window,
                                  coinc_window, channels=triggered_channels,  number_of_coincidences=number_concidences)
+        trigger.set_triggered_channels(channels_that_passed_trigger) 
 
         if not has_triggered:
             trigger.set_triggered(False)

--- a/NuRadioReco/modules/trigger/simpleThreshold.py
+++ b/NuRadioReco/modules/trigger/simpleThreshold.py
@@ -83,7 +83,7 @@ class triggerSimulator:
             triggerd_bins = get_threshold_triggers(trace, threshold)
             triggerd_bins_channels.append(triggerd_bins)
             if True in triggerd_bins:
-                channels_that_passed_trigger.append(channel)
+                channels_that_passed_trigger.append(channel.get_id())
 
         has_triggered, triggered_bins, triggered_times = get_majority_logic(
             triggerd_bins_channels, number_concidences, coinc_window, dt)

--- a/NuRadioReco/modules/trigger/simpleThreshold.py
+++ b/NuRadioReco/modules/trigger/simpleThreshold.py
@@ -71,6 +71,7 @@ class triggerSimulator:
                 break
         else:
             channel_trace_start_time = station.get_channel(triggered_channels[0]).get_trace_start_time()
+        channels_that_passed_trigger = []
         for channel in station.iter_channels():
             channel_id = channel.get_id()
             if triggered_channels is not None and channel_id not in triggered_channels:
@@ -81,6 +82,8 @@ class triggerSimulator:
             trace = channel.get_trace()
             triggerd_bins = get_threshold_triggers(trace, threshold)
             triggerd_bins_channels.append(triggerd_bins)
+            if True in triggerd_bins:
+                channels_that_passed_trigger.append(channel)
 
         has_triggered, triggered_bins, triggered_times = get_majority_logic(
             triggerd_bins_channels, number_concidences, coinc_window, dt)
@@ -92,6 +95,7 @@ class triggerSimulator:
             station.set_parameter(stnp.channels_max_amplitude, max_signal)
         trigger = SimpleThresholdTrigger(trigger_name, threshold, triggered_channels,
                                          number_concidences)
+        trigger.set_triggered_channels(channels_that_passed_trigger) 
         if has_triggered:
             trigger.set_triggered(True)
             trigger.set_trigger_time(triggered_times.min())


### PR DESCRIPTION
Lets the trigger class store the IDs of the channels that triggered. Makes the simple- highLow and multiHighLow-trigger simulators set this accordingly