### PR TITLE
Io improvements

### DIFF
--- a/NuRadioReco/modules/io/NuRadioRecoio.py
+++ b/NuRadioReco/modules/io/NuRadioRecoio.py
@@ -16,7 +16,18 @@ VERSION_MINOR = 1
 class NuRadioRecoio(object):
 
     def __init__(self, filenames, parse_header=True, fail_on_version_mismatch=True,
-                 fail_on_minor_version_mismatch=False):
+                 fail_on_minor_version_mismatch=False,
+                 max_open_files=10):
+        """
+        Initialize NuRadioReco io
+        
+        Parameters
+        ----------
+        filenames: string or list of strings
+            the input file/files
+        max_open_files: int
+            the maximum number of files that remain open simultaneously
+        """
         if(not isinstance(filenames, list)):
             filenames = [filenames]
         self.__file_scanned = False
@@ -26,8 +37,24 @@ class NuRadioRecoio(object):
         self.__fail_on_minor_version_mismatch = fail_on_minor_version_mismatch
         self.__parse_header = parse_header
         self.__read_lock = False
+        self.__max_open_files = max_open_files
         self.openFile(filenames)
         logger.info("... finished in {:.0f} seconds".format(time.time() - t))
+        
+    def __get_file(self, iF):
+        if(iF not in self.__open_files):
+            self.__open_files[iF] = {} 
+            self.__open_files[iF]['file'] = open(self.__filenames[iF], 'rb')
+            self.__open_files[iF]['time'] = time.time()
+            if(len(self.__open_files) > self.__max_open_files):
+                tnow = time.time()
+                iF_close = 0
+                for key, value in self.__open_files.iteritems():
+                    if(value['time'] < tnow):
+                        iF_close = key
+                self.__open_files[iF_close]['file'].close()
+                del self.__open_files[iF_close]
+        return self.__open_files[iF]['file']
 
     def openFile(self, filenames):
         self.__filenames = filenames
@@ -37,11 +64,10 @@ class NuRadioRecoio(object):
         self.__bytes_length_header = [[]]
         self.__bytes_start = [[]]
         self.__bytes_length = [[]]
-        self.__fin = []
+        self.__open_files = {}
         for iF, filename in enumerate(filenames):
-            self.__fin.append(open(filename, 'rb'))
-            self.__file_version = int(self.__fin[iF].read(6), 16)
-            self.__file_version_minor = int(self.__fin[iF].read(6), 16)
+            self.__file_version = int(self.__get_file(iF).read(6), 16)
+            self.__file_version_minor = int(self.__get_file(iF).read(6), 16)
             if(self.__file_version != VERSION):
                 logger.error("data file not readable. File has version {}.{} but current version is {}.{}".format(self.__file_version, self.__file_version_minor,
                                                                                                                   VERSION, VERSION_MINOR))
@@ -58,8 +84,8 @@ class NuRadioRecoio(object):
             self.__scan_files()
 
     def close_files(self):
-        for f in self.__fin:
-            f.close()
+        for f in self.__open_files:
+            f['file'].close()
 
     def get_filenames(self):
         return self.__filenames
@@ -87,15 +113,15 @@ class NuRadioRecoio(object):
         current_byte = 12  # skip datafile header
         iF = 0
         while True:
-            self.__fin[iF].seek(current_byte)
-            bytes_to_read_hex = self.__fin[iF].read(6)
+            self.__get_file(iF).seek(current_byte)
+            bytes_to_read_hex = self.__get_file(iF).read(6)
             if(bytes_to_read_hex == ''):
                 # we are at the end of the file
-                if(iF < (len(self.__fin) - 1)):  # are there more files to be parsed?
+                if(iF < (len(self.__filenames) - 1)):  # are there more files to be parsed?
                     iF += 1
                     current_byte = 12  # skip datafile header
-                    self.__fin[iF].seek(current_byte)
-                    bytes_to_read_hex = self.__fin[iF].read(6)
+                    self.__get_file(iF).seek(current_byte)
+                    bytes_to_read_hex = self.__get_file(iF).read(6)
                     self.__bytes_start_header.append([])
                     self.__bytes_length_header.append([])
                     self.__bytes_start.append([])
@@ -108,11 +134,11 @@ class NuRadioRecoio(object):
             self.__bytes_length_header[iF].append(bytes_to_read)
             current_byte += bytes_to_read
 
-            evt_header = pickle.loads(self.__fin[iF].read(bytes_to_read))
+            evt_header = pickle.loads(self.__get_file(iF).read(bytes_to_read))
             self.__parse_event_header(evt_header)
 
-            self.__fin[iF].seek(current_byte)
-            bytes_to_read_hex = self.__fin[iF].read(6)
+            self.__get_file(iF).seek(current_byte)
+            bytes_to_read_hex = self.__get_file(iF).read(6)
             current_byte += 6
             bytes_to_read = int(bytes_to_read_hex, 16)
             self.__bytes_start[iF].append(current_byte)
@@ -161,7 +187,7 @@ class NuRadioRecoio(object):
         # determine in which file event i is
         istart = 0
         file_id = 0
-        for iF in range(len(self.__fin)):
+        for iF in range(len(self.__filenames)):
             istop = istart + len(self.__bytes_start[iF])
             if((event_number >= istart) and (event_number < istop)):
                 file_id = iF
@@ -170,8 +196,8 @@ class NuRadioRecoio(object):
             else:
                 istart = istop
 
-        self.__fin[file_id].seek(self.__bytes_start[file_id][event_id])
-        evtstr = self.__fin[file_id].read(self.__bytes_length[file_id][event_id])
+        self.__get_file(file_id).seek(self.__bytes_start[file_id][event_id])
+        evtstr = self.__get_file(file_id).read(self.__bytes_length[file_id][event_id])
         event = NuRadioReco.framework.event.Event(0, 0)
         event.deserialize(evtstr)
         self.__read_lock = False
@@ -188,23 +214,23 @@ class NuRadioRecoio(object):
 
     def get_events(self):
         iF = 0
-        self.__fin[iF].seek(12)  # skip file header
+        self.__get_file(iF).seek(12)  # skip file header
         while True:
-            bytes_to_read_hex = self.__fin[iF].read(6)
+            bytes_to_read_hex = self.__get_file(iF).read(6)
             if(bytes_to_read_hex == ''):
                 # we are at the end of the file
-                if(iF < (len(self.__fin) - 1)):  # are there more files to be parsed?
+                if(iF < (len(self.__filenames) - 1)):  # are there more files to be parsed?
                     iF += 1
-                    self.__fin[iF].seek(12)  # skip datafile header
-                    bytes_to_read_hex = self.__fin[iF].read(6)
+                    self.__get_file(iF).seek(12)  # skip datafile header
+                    bytes_to_read_hex = self.__get_file(iF).read(6)
                 else:
                     break
             bytes_to_read = int(bytes_to_read_hex, 16)
-            evt_header_str = self.__fin[iF].read(bytes_to_read)
+            evt_header_str = self.__get_file(iF).read(bytes_to_read)
 
-            bytes_to_read_hex = self.__fin[iF].read(6)
+            bytes_to_read_hex = self.__get_file(iF).read(6)
             bytes_to_read = int(bytes_to_read_hex, 16)
-            evtstr = self.__fin[iF].read(bytes_to_read)
+            evtstr = self.__get_file(iF).read(bytes_to_read)
             event = NuRadioReco.framework.event.Event(0, 0)
             event.deserialize(evtstr)
             yield event

--- a/NuRadioReco/modules/io/NuRadioRecoio.py
+++ b/NuRadioReco/modules/io/NuRadioRecoio.py
@@ -17,7 +17,7 @@ class NuRadioRecoio(object):
 
     def __init__(self, filenames, parse_header=True, fail_on_version_mismatch=True,
                  fail_on_minor_version_mismatch=False,
-                 max_open_files=10):
+                 max_open_files=10, log_level=logging.WARNING):
         """
         Initialize NuRadioReco io
         
@@ -33,6 +33,7 @@ class NuRadioRecoio(object):
         self.__file_scanned = False
         logger.info("initializing NuRadioRecoio with file {}".format(filenames))
         t = time.time()
+        logger.setLevel(log_level)
         self.__fail_on_version_mismatch = fail_on_version_mismatch
         self.__fail_on_minor_version_mismatch = fail_on_minor_version_mismatch
         self.__parse_header = parse_header
@@ -43,15 +44,19 @@ class NuRadioRecoio(object):
         
     def __get_file(self, iF):
         if(iF not in self.__open_files):
+            logger.debug("file {} is not yet open, opening file".format(iF))
             self.__open_files[iF] = {} 
             self.__open_files[iF]['file'] = open(self.__filenames[iF], 'rb')
             self.__open_files[iF]['time'] = time.time()
             if(len(self.__open_files) > self.__max_open_files):
+                logger.debug("more than {} file are open, closing oldest file".format(self.__max_open_files))
                 tnow = time.time()
                 iF_close = 0
                 for key, value in self.__open_files.iteritems():
                     if(value['time'] < tnow):
+                        tnow = value['time'] 
                         iF_close = key
+                logger.debug("closing file {} that was opened at {}".format(iF_close, tnow))
                 self.__open_files[iF_close]['file'].close()
                 del self.__open_files[iF_close]
         return self.__open_files[iF]['file']

--- a/NuRadioReco/modules/io/eventReader.py
+++ b/NuRadioReco/modules/io/eventReader.py
@@ -9,8 +9,8 @@ class eventReader:
     read events from file
     """
 
-    def begin(self, filename):
-        self.__fin = NuRadioRecoio.NuRadioRecoio(filename, parse_header=False)
+    def begin(self, filename, log_level=logging.WARNING):
+        self.__fin = NuRadioRecoio.NuRadioRecoio(filename, parse_header=False, log_level=log_level)
 
     def run(self):
         return self.__fin.get_events()


### PR DESCRIPTION
restrict number of simultaneously open files. Default is 10. This fixes a problem that we are experiencing on HPC when trying to process 10k files at once. 
I don't see any downside of this new implementation. There might be a slight overhead when reopening files but this should only rarely happen. It is already rare to have more than 10 input files. And as long the files are read in sequentially each file will get opened only once (or twice if the header is parsed in the beginning). 