### PR TITLE
make reader work for python3

### DIFF
--- a/NuRadioReco/modules/io/snowshovel/readARIANNADataCalib.py
+++ b/NuRadioReco/modules/io/snowshovel/readARIANNADataCalib.py
@@ -67,12 +67,12 @@ class readARIANNAData:
         self.calwv = ROOT.TSnCalWvData()
         if(tree == 'RawData'):
             self.calwv = ROOT.TSnRawWaveform()
-        self.data_tree.SetBranchAddress("{}.".format(tree), self.calwv)
+        self.data_tree.SetBranchAddress("{}.".format(tree), ROOT.AddressOf(self.calwv))
 #         self.data_tree.SetBranchAddress("AmpOutData.", self.calwv)
 
         self.readout_config = ROOT.TSnReadoutConfig()
 
-        self.config_tree.SetBranchAddress("ReadoutConfig.", self.readout_config)
+        self.config_tree.SetBranchAddress("ReadoutConfig.", ROOT.AddressOf(self.readout_config))
         self.skipped_events = 0
         self.skipped_events_stop = 0
 


### PR DESCRIPTION
I tested this on snowflake. I can read in the data with python3. It doesn't crash but I did not verify that the data is valid. 