### PR TITLE
Generic detector

### DIFF
--- a/NuRadioReco/detector/detector.py
+++ b/NuRadioReco/detector/detector.py
@@ -165,7 +165,7 @@ class Detector(object):
             self.__db = TinyDB(filename, storage=serialization,
                                sort_keys=True, indent=4, separators=(',', ': '))
 
-        self.__stations = self.__db.table('stations', cache_size=1000)
+        self._stations = self.__db.table('stations', cache_size=1000)
         self.__channels = self.__db.table('channels', cache_size=1000)
         self.__positions = self.__db.table('positions', cache_size=1000)
 
@@ -207,7 +207,7 @@ class Detector(object):
         Station = Query()
         if self.__current_time is None:
             raise ValueError("Detector time is not set. The detector time has to be set using the Detector.update() function before it can be used.")
-        res = self.__stations.get((Station.station_id == station_id)
+        res = self._stations.get((Station.station_id == station_id)
                                        & (Station.commission_time <= self.__current_time.datetime)
                                        & (Station.decommission_time > self.__current_time.datetime))
         if(res is None):
@@ -230,7 +230,7 @@ class Detector(object):
         returns a sorted list of all station ids present in the database
         """
         station_ids = []
-        res = self.__stations.all()
+        res = self._stations.all()
         if(res is None):
             logger.error("query for stations returned no results")
             raise LookupError("query for stations returned no results")
@@ -275,7 +275,7 @@ class Detector(object):
             
     def __get_t0_t1(self, station_id):
         Station = Query()
-        res = self.__stations.get(Station.station_id == station_id)
+        res = self._stations.get(Station.station_id == station_id)
         t0 = None
         t1 = None
         if(isinstance(res, list)):
@@ -305,7 +305,7 @@ class Detector(object):
         Returns bool
         """
         Station = Query()
-        res = self.__stations.get(Station.station_id == station_id)
+        res = self._stations.get(Station.station_id == station_id)
         return res != None
     
     def get_unique_time_periods(self, station_id):

--- a/NuRadioReco/detector/detector.py
+++ b/NuRadioReco/detector/detector.py
@@ -171,9 +171,9 @@ class Detector(object):
 
         logger.info("database initialized")
 
-        self.__buffered_stations = {}
+        self._buffered_stations = {}
         self.__buffered_positions = {}
-        self.__buffered_channels = {}
+        self._buffered_channels = {}
         self.__valid_t0 = astropy.time.Time('2100-1-1')
         self.__valid_t1 = astropy.time.Time('1970-1-1')
 
@@ -240,9 +240,9 @@ class Detector(object):
         return sorted(station_ids)
 
     def __get_station(self, station_id):
-        if(station_id not in self.__buffered_stations.keys()):
-            self.__buffer(station_id)
-        return self.__buffered_stations[station_id]
+        if(station_id not in self._buffered_stations.keys()):
+            self._buffer(station_id)
+        return self._buffered_stations[station_id]
     
     def __get_position(self, position_id):
         if(position_id not in self.__buffered_positions.keys()):
@@ -250,23 +250,23 @@ class Detector(object):
         return self.__buffered_positions[position_id]
 
     def __get_channels(self, station_id):
-        if(station_id not in self.__buffered_stations.keys()):
-            self.__buffer(station_id)
-        return self.__buffered_channels[station_id]
+        if(station_id not in self._buffered_stations.keys()):
+            self._buffer(station_id)
+        return self._buffered_channels[station_id]
 
     def __get_channel(self, station_id, channel_id):
-        if(station_id not in self.__buffered_stations.keys()):
-            self.__buffer(station_id)
-        return self.__buffered_channels[station_id][channel_id]
+        if(station_id not in self._buffered_stations.keys()):
+            self._buffer(station_id)
+        return self._buffered_channels[station_id][channel_id]
 
-    def __buffer(self, station_id):
-        self.__buffered_stations[station_id] = self._query_station(station_id)
-        self.__valid_t0 = astropy.time.Time(self.__buffered_stations[station_id]['commission_time'])
-        self.__valid_t1 = astropy.time.Time(self.__buffered_stations[station_id]['decommission_time'])
+    def _buffer(self, station_id):
+        self._buffered_stations[station_id] = self._query_station(station_id)
+        self.__valid_t0 = astropy.time.Time(self._buffered_stations[station_id]['commission_time'])
+        self.__valid_t1 = astropy.time.Time(self._buffered_stations[station_id]['decommission_time'])
         channels = self._query_channels(station_id)
-        self.__buffered_channels[station_id] = {}
+        self._buffered_channels[station_id] = {}
         for channel in channels:
-            self.__buffered_channels[station_id][channel['channel_id']] = channel
+            self._buffered_channels[station_id][channel['channel_id']] = channel
             self.__valid_t0 = max(self.__valid_t0, astropy.time.Time(channel['commission_time']))
             self.__valid_t1 = min(self.__valid_t1, astropy.time.Time(channel['decommission_time']))
             
@@ -325,7 +325,7 @@ class Detector(object):
         while True:
             if(len(up) > 0 and up[-1] == t1):
                 break
-            self.__buffer(station_id)
+            self._buffer(station_id)
             if(len(up) == 0):
                 up.append(self.__valid_t0)
             up.append(self.__valid_t1)
@@ -348,8 +348,8 @@ class Detector(object):
             self.__current_time = time
         logger.info("updating detector time to {}".format(self.__current_time))
         if(not ((self.__current_time > self.__valid_t0) and (self.__current_time < self.__valid_t1))):
-            self.__buffered_stations = {}
-            self.__buffered_channels = {}
+            self._buffered_stations = {}
+            self._buffered_channels = {}
             self.__valid_t0 = astropy.time.Time('2100-1-1')
             self.__valid_t1 = astropy.time.Time('1970-1-1')
             

--- a/NuRadioReco/detector/detector.py
+++ b/NuRadioReco/detector/detector.py
@@ -166,7 +166,7 @@ class Detector(object):
                                sort_keys=True, indent=4, separators=(',', ': '))
 
         self._stations = self.__db.table('stations', cache_size=1000)
-        self.__channels = self.__db.table('channels', cache_size=1000)
+        self._channels = self.__db.table('channels', cache_size=1000)
         self.__positions = self.__db.table('positions', cache_size=1000)
 
         logger.info("database initialized")
@@ -187,7 +187,7 @@ class Detector(object):
         Channel = Query()
         if self.__current_time is None:
             raise ValueError("Detector time is not set. The detector time has to be set using the Detector.update() function before it can be used.")
-        res = self.__channels.get((Channel.station_id == station_id) & (Channel.channel_id == channel_id)
+        res = self._channels.get((Channel.station_id == station_id) & (Channel.channel_id == channel_id)
                                            & (Channel.commission_time <= self.__current_time.datetime)
                                            & (Channel.decommission_time > self.__current_time.datetime))
         if(res is None):
@@ -195,15 +195,15 @@ class Detector(object):
             raise LookupError
         return res
 
-    def __query_channels(self, station_id):
+    def _query_channels(self, station_id):
         Channel = Query()
         if self.__current_time is None:
             raise ValueError("Detector time is not set. The detector time has to be set using the Detector.update() function before it can be used.")
-        return self.__channels.search((Channel.station_id == station_id)
+        return self._channels.search((Channel.station_id == station_id)
                                            & (Channel.commission_time <= self.__current_time.datetime)
                                            & (Channel.decommission_time > self.__current_time.datetime))
 
-    def __query_station(self, station_id):
+    def _query_station(self, station_id):
         Station = Query()
         if self.__current_time is None:
             raise ValueError("Detector time is not set. The detector time has to be set using the Detector.update() function before it can be used.")
@@ -260,10 +260,10 @@ class Detector(object):
         return self.__buffered_channels[station_id][channel_id]
 
     def __buffer(self, station_id):
-        self.__buffered_stations[station_id] = self.__query_station(station_id)
+        self.__buffered_stations[station_id] = self._query_station(station_id)
         self.__valid_t0 = astropy.time.Time(self.__buffered_stations[station_id]['commission_time'])
         self.__valid_t1 = astropy.time.Time(self.__buffered_stations[station_id]['decommission_time'])
-        channels = self.__query_channels(station_id)
+        channels = self._query_channels(station_id)
         self.__buffered_channels[station_id] = {}
         for channel in channels:
             self.__buffered_channels[station_id][channel['channel_id']] = channel

--- a/NuRadioReco/detector/generic_detector.py
+++ b/NuRadioReco/detector/generic_detector.py
@@ -1,0 +1,68 @@
+import os
+import astropy.time
+import logging
+from tinydb import TinyDB, Query
+from tinydb_serialization import SerializationMiddleware
+from tinydb.storages import MemoryStorage
+from tinydb_serialization import Serializer
+import NuRadioReco.detector.detector
+from NuRadioReco.detector.detector import DateTimeSerializer
+
+logger = logging.getLogger('genericDetector')
+logging.basicConfig()
+
+serialization = SerializationMiddleware()
+serialization.register_serializer(DateTimeSerializer(), 'TinyDate')
+
+
+class GenericDetector(NuRadioReco.detector.detector.Detector):
+    """
+    Used the same way as the main detector class, but works with incomplete
+    detector descriptions.
+    The user can define a default station and a default channel. If any
+    information is missing, the value stored in the default station or default
+    channel will be used instead.
+    The GenericDetector also ignores commission and decommision times and should
+    therefore not be used for real data, but only for simulation studies.
+    This detector only accepts json detector descriptions.
+    """
+    def __init__(self, json_filename, default_station, default_channel=None, assume_inf=True):
+        """
+        Initialize the stations detector properties.
+
+        Parameters
+        ----------
+        json_filename : str
+            the path to the json detector description file (if first checks a path relative to this directory, then a
+            path relative to the current working directory of the user)
+            default value is 'ARIANNA/arianna_detector_db.json'
+        default_station:
+            ID of the station that should be used as the default station. The default station needs to have a complete detector
+            description. If a property is missing in any of the other stations, the value from the default station will be used instead
+        default_channel:
+            ID of the channel that should be used as the default channel. This channel has to be part of the default station and have a
+            complete detector description. If a property is missing in any of the other channels, the value from the default channel 
+            will be used instead.
+        assume_inf : Bool
+            Default to True, if true forces antenna madels to have infinite boundary conditions, otherwise the antenna madel will be determined by the station geometry.
+        """
+        super(GenericDetector, self).__init__('json', json_filename, assume_inf)
+        self.__default_station_id = default_station
+        if not self.has_station(self.__default_station_id):
+            raise ValueError('The default station {} was not found in the detector description'.format(self.__default_station_id)) 
+        Station = Query()
+        #if self.__current_time is None:
+        #    raise ValueError("Detector time is not set. The detector time has to be set using the Detector.update() function before it can be used.")
+        self.__default_station = self._stations.get((Station.station_id == self.__default_station_id))
+    def get_station(self, station_id):
+        return self.__query_station(station_id)
+    def __query_station(self, station_id):
+        Station = Query()
+        res = self._stations.get((Station.station_id == station_id))
+        if(res is None):
+            logger.error("query for station {} returned no results".format(station_id))
+            raise LookupError("query for station {} returned no results".format(station_id))
+        for key in self.__default_station.keys():
+            if key not in res.keys():
+                res[key] = self.__default_station[key]
+        return res


### PR DESCRIPTION
Adds GenericDetector class that makes it easier to define detector descriptions for simulation studies.
Instead of fully defining every part of the detector, one can just define a default station and (optional) default channel. In all other stations and channels, only the properties that differ from those need to be specified. This makes it much more convenient to create new detector designs for simulation studies.