### PR TITLE
Fixes ARA hardwareResponseIncorporator

### DIFF
--- a/NuRadioReco/modules/ARA/hardwareResponseIncorporator.py
+++ b/NuRadioReco/modules/ARA/hardwareResponseIncorporator.py
@@ -45,7 +45,8 @@ class hardwareResponseIncorporator:
                 channel.set_frequency_spectrum(trace_after_system_fft, channel.get_sampling_rate())
 
             else:
-                trace_before_system_fft = trace_fft / (system_response['gain'] * system_response['phase'])
+                trace_before_system_fft = np.zeros_like(trace_fft)
+                trace_before_system_fft[np.abs(system_response['gain']) > 0] = trace_fft[np.abs(system_response['gain']) > 0] / (system_response['gain'] * system_response['phase'])[np.abs(system_response['gain']) > 0]
                 channel.set_frequency_spectrum(trace_before_system_fft, channel.get_sampling_rate())
 
         self.__t += time.time() - t

--- a/NuRadioReco/modules/ARA/hardwareResponseIncorporator.py
+++ b/NuRadioReco/modules/ARA/hardwareResponseIncorporator.py
@@ -30,12 +30,11 @@ class hardwareResponseIncorporator:
         t = time.time()
         station_id = station.get_id()
         channels = station.iter_channels()
-        frequencies = channels[0].get_frequencies()  #the sampling rate is assumed to be the same for all channels
-        # very basic, only one system response for the whole ARA system
-        system_response = analog_components.get_system_response(frequencies)
 
         for channel in channels:
 
+            frequencies = channel.get_frequencies()
+            system_response = analog_components.get_system_response(frequencies)
             trace_fft = channel.get_frequency_spectrum()
 
             if sim_to_data:


### PR DESCRIPTION
Fixes ARA hardwareResponseIncorporator. This bug was introduced when the get_channels function was changed to return an iterator.