### PR TITLE
fix sign error in r_p coefficient. 

### DIFF
--- a/NuRadioReco/utilities/geometryUtilities.py
+++ b/NuRadioReco/utilities/geometryUtilities.py
@@ -109,6 +109,8 @@ def get_fresnel_t_p(zenith_incoming, n_2=1.3, n_1=1.):
     of the incoming radiation."
     """
     zenith_outgoing = get_fresnel_angle(zenith_incoming, n_2, n_1)
+    if(zenith_outgoing is None):
+        return 0
     t = 2 * n_1 * np.cos(zenith_incoming) / (n_1 * np.cos(zenith_outgoing) + n_2 * np.cos(zenith_incoming))
     return t
 
@@ -124,6 +126,8 @@ def get_fresnel_t_s(zenith_incoming, n_2=1.3, n_1=1.):
     of the incoming radiation."
     """
     zenith_outgoing = get_fresnel_angle(zenith_incoming, n_2, n_1)
+    if(zenith_outgoing is None):
+        return 0
     t = 2 * n_1 * np.cos(zenith_incoming) / (n_1 * np.cos(zenith_incoming) + n_2 * np.cos(zenith_outgoing))
     return t
 
@@ -139,7 +143,7 @@ def get_fresnel_r_p(zenith_incoming, n_2=1.3, n_1=1.):
     of the incoming radiation."
     """
     n = n_2/n_1
-    return (-n**2 * np.cos(zenith_incoming) + SM.sqrt(n**2 - np.sin(zenith_incoming)**2)) / \
+    return (n**2 * np.cos(zenith_incoming) - SM.sqrt(n**2 - np.sin(zenith_incoming)**2)) / \
               (n**2 * np.cos(zenith_incoming) + SM.sqrt(n**2 - np.sin(zenith_incoming)**2))
 
 


### PR DESCRIPTION
The calculation of the Fresnel reflection and transmission coefficients are based on https://en.wikipedia.org/wiki/Fresnel_equations#Amplitude_reflection_and_transmission_coefficients. For total internal reflection cases, the formulas need to be modified as the outgoing angle is undefined. This is done in the following PDF document. 

[Fresnel_reflection_coefficients.pdf](https://github.com/nu-radio/NuRadioReco/files/3364126/Fresnel_reflection_coefficients.pdf)

For TIR incident angles, the reflection coefficients have magnitude one and change phase dependent on the incident angle. The previous implementation had a -1 error in the r_p coefficient. 

I also changed the code to return 0 for transmission coefficients for TIR cases