### PR TITLE
add output when antenna model is locally replaced

### DIFF
--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -1058,6 +1058,8 @@ class AntennaPatternProvider(object):
             documentation of this class for further information)
         """
         if(name in self._antenna_model_replacements.keys()):
+            if(self._antenna_model_replacements[name] not in self._open_antenna_patterns.keys()):
+                logger.warning("local replacement of antenna model requsted: replacing {} with {}".format(name, self._antenna_model_replacements[name]))
             name = self._antenna_model_replacements[name]
         if (name not in self._open_antenna_patterns.keys()):
             if(name.startswith("analytic")):


### PR DESCRIPTION
NuRadioReco has the ability to define a file that replaces antenna models. This is usefull if someone wants to study impacts of different antenna patterns. The dangerous thing is, that we don't keep track of this. I added that at least a logger message is provided, but this information is lost in the output files... It will be difficult to implement to properly save this information in the output files (at least in accordance to how it is implemented now). 
One option is to just remove this functionality, but this would reduce convenience.