### PR TITLE
Makes stations store triggers and channels in an ordred dict

### DIFF
--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -11,6 +11,7 @@ try:
 except ImportError:
     import pickle
 import logging
+import collections
 logger = logging.getLogger('BaseStation')
 
 
@@ -22,7 +23,7 @@ class BaseStation():
         self._parameter_covariances = {}
         self._station_id = station_id
         self._station_time = None
-        self._triggers = {}
+        self._triggers = collections.OrderedDict()
         self._triggered = False
         self._electric_fields = []
         self._particle_type = ''

--- a/NuRadioReco/framework/station.py
+++ b/NuRadioReco/framework/station.py
@@ -8,6 +8,7 @@ try:
 except ImportError:
     import pickle
 import logging
+import collections
 logger = logging.getLogger('Station')
 
 
@@ -15,7 +16,7 @@ class Station(NuRadioReco.framework.base_station.BaseStation):
 
     def __init__(self, station_id):
         NuRadioReco.framework.base_station.BaseStation.__init__(self, station_id)
-        self.__channels = {}
+        self.__channels = collections.OrderedDict()
         self.__reference_reconstruction = 'RD'
         self.__sim_station = None
 


### PR DESCRIPTION
Triggers and channels are stored in an ordered dict, to make unit tests easier and avoid errors.
E-Fields are stored in an array, so their ordering is conserved anyway.