### PR TITLE
Unit test fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_script:
   - unzip /tmp/radiotools.zip
   - mv radiotools-master radiotools
   - export PYTHONPATH=$PWD/radiotools
-  - wget https://github.com/nu-radio/NuRadioMC/archive/python3.zip -O /tmp/NuRadioMC.zip
+  - wget https://github.com/nu-radio/NuRadioMC/archive/master.zip -O /tmp/NuRadioMC.zip
   - unzip /tmp/NuRadioMC.zip
-  - mv NuRadioMC-python3 NuRadioMC
+  - mv NuRadioMC-master NuRadioMC
   - export PYTHONPATH=$PYTHONPATH:$PWD/NuRadioMC
   - export PYTHONPATH=$PYTHONPATH:$PWD
   - wget http://arianna.ps.uci.edu/~arianna/data/AntennaModels/createLPDA_100MHz_InfFirn/createLPDA_100MHz_InfFirn.pkl
@@ -34,4 +34,3 @@ jobs:
       name: "Trigger tests"
     - script: NuRadioReco/test/test_examples.sh
       name: "Test all examples"
-

--- a/NuRadioReco/test/test_examples.sh
+++ b/NuRadioReco/test/test_examples.sh
@@ -1,3 +1,4 @@
+set -e
 cd NuRadioReco/examples/PhasedArray/Effective_volume
 python T01generate_event_list.py minimal
 python T02RunPhasedRNO.py --inputfilename minimal_eventlist.hdf5

--- a/NuRadioReco/test/tiny_reconstruction/testTinyReconstruction.sh
+++ b/NuRadioReco/test/tiny_reconstruction/testTinyReconstruction.sh
@@ -1,3 +1,4 @@
+set -e
 cd NuRadioReco/test/tiny_reconstruction
 python TinyReconstruction.py
 python compareToReference.py MC_example_station_32.nur reference.json

--- a/NuRadioReco/test/trigger_tests/run_trigger_test.sh
+++ b/NuRadioReco/test/trigger_tests/run_trigger_test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -e
 python NuRadioReco/test/trigger_tests/generate_events.py
 python NuRadioReco/test/trigger_tests/trigger_tests.py
 python NuRadioReco/test/trigger_tests/compare_to_reference.py


### PR DESCRIPTION
- Makes travis check out the NuRadiomC main branch, now that the python3 branch has been merged.
- The shell scripts can catch errors in the python scripts and keep running, so that the unit test passes when it really shouldn't. Adding set -e to the scripts stops that from happening.