### PR TITLE
Efield filter arguments

### DIFF
--- a/NuRadioReco/examples/SimpleMCReconstruction.py
+++ b/NuRadioReco/examples/SimpleMCReconstruction.py
@@ -151,7 +151,7 @@ for iE, evt in enumerate(readCoREAS.run(detector=det)):
 
         # traditional
         voltageToEfieldConverter.run(evt, station, det, use_channels=used_channels_efield, use_MC_direction=True)
-        electricFieldBandPassFilter.run(evt, station, det, passband=[30 * units.MHz, 80 * units.MHz])
+        electricFieldBandPassFilter.run(evt, station, det, passband=[30 * units.MHz, 80 * units.MHz], filter_type='butter', order=10)
         electricFieldSignalReconstructor.run(evt, station, det)
 
         # channelSignalReconstructor.run(evt, station, det)

--- a/NuRadioReco/modules/channelBandPassFilter.py
+++ b/NuRadioReco/modules/channelBandPassFilter.py
@@ -1,4 +1,4 @@
-from __future__ import print_function 
+from __future__ import print_function
 
 import numpy as np
 from scipy import signal
@@ -37,7 +37,7 @@ class channelBandPassFilter:
             or 'FIR <type> <parameter>' - see below for FIR filter options
         order: int (optional, default 2)
             for a butterworth filter: specifies the order of the filter
-        
+
         Added Jan-07-2018 by robert.lahmann@fau.de:
         FIR filter:
         see https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.get_window.html
@@ -47,38 +47,34 @@ class channelBandPassFilter:
         filter_type='FIR hamming': same as above
         filter_type='FIR kaiser 10' : Use Kaiser window with beta parameter 10
         filter_type='FIR kaiser' : Use Kaiser window with default beta parameter 6
-        
+
         In principal, window names are just passed on to signal.firwin(), but if parameters
         are required, then these cases must be explicitly implemented in the code below.
-        
-        The for main filter types can be implemented: 
+
+        The for main filter types can be implemented:
         LP: passband[0]=None, passband[1]  = f_cut
         HP: passband[0]=f_cut, passband[1] = None
         BP: passband[0]=f_cut_low, passband[1] = f_cut_high
         BS: passband[0]=f_cut_high, passband[1] = f_cut_low (i.e. passband[0] > passband[1])
-        
+
         """
-        
+
         for channel in station.iter_channels():
-            if isinstance(station, NuRadioReco.framework.sim_station.SimStation):
-                for sub_channel in channel:
-                    self.__apply_filter(sub_channel, passband, filter_type, order, True)
-            else:
-                self.__apply_filter(channel, passband, filter_type, order, False)
-            
+            self.__apply_filter(channel, passband, filter_type, order, False)
+
     def __apply_filter(self, channel, passband, filter_type, order, is_efield=False):
         frequencies = channel.get_frequencies()
         trace_fft = channel.get_frequency_spectrum()
         sample_rate = channel.get_sampling_rate()
-        
+
         # for FIR filters, it is easier to set the trace rather than the FFT to apply the
         # filter response. Eventually, I (Robert Lahmann) might figure out a way to set the
         # FFT (as is done for the IIR filters corresponding to analog filters) but for now
-        # I am setting a variable to decide whether the FFT or time trace shall be used to 
-        # set the trace. 
+        # I am setting a variable to decide whether the FFT or time trace shall be used to
+        # set the trace.
 
         isFIR = False
-        
+
         if(filter_type == 'rectangular'):
             if is_efield:
                 for polarization in trace_fft:
@@ -144,10 +140,10 @@ class channelBandPassFilter:
             #print('fcut = ',fcut)
             taps = signal.firwin(Nfir, fcut, window=wtype,scale=False,pass_zero=pass_zero,fs=sample_rate)
             wfilt, hfilt = signal.freqz(taps, worN=len(frequencies))
-            
+
             if ((Nfir//2)*2==Nfir):
                 print("odd filter order, rolling is off by T_s/2")
-                
+
             ndelay = int(0.5 * (Nfir-1))
             trace_fir = signal.lfilter(taps, 1.0, channel.get_trace())
             #print('len(trace_fir)',len(trace_fir))

--- a/NuRadioReco/modules/channelBandPassFilter.py
+++ b/NuRadioReco/modules/channelBandPassFilter.py
@@ -51,7 +51,7 @@ class channelBandPassFilter:
         In principal, window names are just passed on to signal.firwin(), but if parameters
         are required, then these cases must be explicitly implemented in the code below.
 
-        The for main filter types can be implemented:
+        The four main filter types can be implemented:
         LP: passband[0]=None, passband[1]  = f_cut
         HP: passband[0]=f_cut, passband[1] = None
         BP: passband[0]=f_cut_low, passband[1] = f_cut_high

--- a/NuRadioReco/modules/electricFieldBandPassFilter.py
+++ b/NuRadioReco/modules/electricFieldBandPassFilter.py
@@ -11,8 +11,7 @@ class electricFieldBandPassFilter:
         pass
 
     def run(self, evt, station, det, passband=[55 * units.MHz, 1000 * units.MHz],
-            filter_type='rectangular',
-            debug=False):
+            filter_type='rectangular', order=2, debug=False):
         """
         Applies bandpass filter to electric field
 
@@ -26,8 +25,12 @@ class electricFieldBandPassFilter:
 
         passband: seq, array
             passband for filter, in phys units
-        filter_type: str
-            chose filter type, rectangular, butter10, butter10abs
+        filter_type: string
+            'rectangular': perfect straight line filter
+            'butter': butterworth filter from scipy
+            'butterabs': absolute of butterworth filter from scipy
+        order: int (optional, default 2)
+            for a butterworth filter: specifies the order of the filter
         debug: bool
             set debug
 
@@ -39,12 +42,12 @@ class electricFieldBandPassFilter:
             if(filter_type == 'rectangular'):
                 trace_fft[:, np.where(frequencies < passband[0])] = 0.
                 trace_fft[:, np.where(frequencies > passband[1])] = 0.
-            elif(filter_type == 'butter10'):
-                b, a = scipy.signal.butter(10, passband, 'bandpass', analog=True)
+            elif(filter_type == 'butter'):
+                b, a = scipy.signal.butter(order, passband, 'bandpass', analog=True)
                 w, h = scipy.signal.freqs(b, a, frequencies)
                 trace_fft *= h
-            elif(filter_type == 'butter10abs'):
-                b, a = scipy.signal.butter(10, passband, 'bandpass', analog=True)
+            elif(filter_type == 'butterabs'):
+                b, a = scipy.signal.butter(order, passband, 'bandpass', analog=True)
                 w, h = scipy.signal.freqs(b, a, frequencies)
                 trace_fft *= np.abs(h)
             efield.set_frequency_spectrum(trace_fft, efield.get_sampling_rate())


### PR DESCRIPTION
Changes the electricFieldBandPass filter to accept arguments in the same way as the channelBandPassFilter
Also removes obsolete code in the channelBandPassFilter. This was left over from when e-Fields were stored in sim_station channels