### PR TITLE
Fixed bug when there are no secondary channels. Changed the definitio…

### DIFF
--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedARA.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedARA.py
@@ -92,7 +92,6 @@ class mySimulation(simulation.simulation):
                              secondary_channels=[0,1,3,4,6,7], # secondary channels
                              trigger_name='primary_and_secondary_phasing', # the name of the trigger
                              set_not_triggered=(not self._station.has_triggered("simple_threshold")),
-                             only_primary=False,
                              coupled=True)
 
 

--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedARA.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedARA.py
@@ -89,6 +89,7 @@ class mySimulation(simulation.simulation):
         triggerSimulator.run(self._evt, self._station, self._det,
                              threshold=2.5 * self._Vrms, # see phased trigger module for explanation
                              triggered_channels=None,  # run trigger on all channels
+                             secondary_channels=[0,1,3,4,6,7], # secondary channels
                              trigger_name='primary_and_secondary_phasing', # the name of the trigger
                              set_not_triggered=(not self._station.has_triggered("simple_threshold")),
                              only_primary=False,

--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedRNO.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedRNO.py
@@ -99,7 +99,6 @@ class mySimulation(simulation.simulation):
                              phasing_angles=phasing_angles,
                              secondary_phasing_angles=secondary_phasing_angles,
                              set_not_triggered=(not self._station.has_triggered("simple_threshold")),
-                             only_primary=True, # no secondary trigger
                              coupled=False,
                              ref_index=1.55)
 

--- a/NuRadioReco/examples/PhasedArray/SNR_curves/T02RunSNR.py
+++ b/NuRadioReco/examples/PhasedArray/SNR_curves/T02RunSNR.py
@@ -158,6 +158,7 @@ class mySimulation(simulation.simulation):
             has_triggered = triggerSimulator.run(self._evt, self._station, self._det,
                                  threshold= 2.5 * self._Vrms,
                                  triggered_channels=None,  # run trigger on all channels
+                                 secondary_channels=[0,1,3,4,6,7], # secondary channels
                                  trigger_name='primary_and_secondary_phasing',
                                  set_not_triggered=(not self._station.has_triggered("simple_threshold")))
 

--- a/NuRadioReco/modules/phasedarray/triggerSimulator.py
+++ b/NuRadioReco/modules/phasedarray/triggerSimulator.py
@@ -170,7 +170,6 @@ class triggerSimulator:
             secondary_phasing_angles=default_sec_angles,
             set_not_triggered=False,
             window_time=10.67 * units.ns,
-            only_primary=False,
             coupled=True,
             ref_index=1.55):
         """
@@ -203,8 +202,6 @@ class triggerSimulator:
             if True not trigger simulation will be performed and this trigger will be set to not_triggered
         window_time: float
             Width of the time window used in the power integration
-        only_primary: bool
-            if True, no secondary beams are formed
         coupled: bool
             if True, the primary sub-beams are paired to the secondary sub-beams.
             if False, the primary sub-beams and the secondary sub-beams specify independent beams.
@@ -234,9 +231,11 @@ class triggerSimulator:
             beam_rolls = self.get_beam_rolls(station, det, triggered_channels, phasing_angles, ref_index=ref_index)
             empty_rolls = [ {} for direction in range(len(phasing_angles)) ]
             logger.debug("secondary_channels:", secondary_channels)
+
             if (len(secondary_channels) == 0):
                 only_primary = True
             else:
+                only_primary = False
                 secondary_beam_rolls = self.get_beam_rolls(station, det, secondary_channels, secondary_phasing_angles, ref_index=ref_index)
 
             if only_primary:

--- a/NuRadioReco/test/trigger_tests/trigger_tests.py
+++ b/NuRadioReco/test/trigger_tests/trigger_tests.py
@@ -33,7 +33,7 @@ for event in event_reader.run():
     high_low_trigger.run(event, station, det, threshold_high=40 * units.mV, threshold_low=-40 * units.mV)
     multi_high_low_trigger.run(event, station, det, trigger_name="default_multi_high_low", threshold_high=40 * units.mV, threshold_low=-40 * units.mV, n_high_lows=2)
     simple_threshold_trigger.run(event, station, det)
-    phased_array_trigger.run(event, station, det, threshold=40 * units.mV)
-    
-    event_writer.run(event)
+    phased_array_trigger.run(event, station, det, threshold=40 * units.mV,
+                             secondary_channels=[0,1,3,4,6,7])
 
+    event_writer.run(event)

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,13 +11,11 @@ new features:
 -Added the internal clock parameter (time since last trigger with ms precision) to ARIANNA paremeters (key number 8)
 -Changed import "detector_sql" to "from NuRadioReco.detector import detector_sql" and .GetSec() to datetime.datetime.fromtimestamp(self.config_tree.TrigStartClock.GetCurrTime()) in the detector.py and readARIANNAdataCalin.py files respectively in order to make it python3 compatible.
 -Updated documentation and made it deployable on github
--Changed normalization of the frequency spectrum. The amplitude is now given as V/GHz (or V/m/GHz for E-fields) instead of
-  V/GHz/bin. This way, the values of trace.get_frequency_spectrum() are independent of the sampling rate. The fft utilities
-  now also need the sampling rate as an argument.
 
 Detector description can be stored in .nur files
 
 bugfixes:
 -Fixes increase in filesize caused by switch to python3
+-Fixed bug when using no secondary channels on the phased array
 
 version 1.0.0 - 2019/08/30 - first python 3 release

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,9 @@ new features:
 -Added the internal clock parameter (time since last trigger with ms precision) to ARIANNA paremeters (key number 8)
 -Changed import "detector_sql" to "from NuRadioReco.detector import detector_sql" and .GetSec() to datetime.datetime.fromtimestamp(self.config_tree.TrigStartClock.GetCurrTime()) in the detector.py and readARIANNAdataCalin.py files respectively in order to make it python3 compatible.
 -Updated documentation and made it deployable on github
+-Changed normalization of the frequency spectrum. The amplitude is now given as V/GHz (or V/m/GHz for E-fields) instead of
+   V/GHz/bin. This way, the values of trace.get_frequency_spectrum() are independent of the sampling rate. The fft utilities
+   now also need the sampling rate as an argument.
 
 Detector description can be stored in .nur files
 


### PR DESCRIPTION
…n of the secondary channels in phased_array. If secondary_channels is None, there are no secondary channels.

Now secondary channels should always be explicitly defined if one wants to use them. This makes sense, since secondary beaming is not being to be used for the Greenland array.
