### PR TITLE
Fix ara trigger

### DIFF
--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T01generate_event_list.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T01generate_event_list.py
@@ -13,7 +13,7 @@ WARNING: This file needs NuRadioMC installed. https://github.com/nu-radio/NuRadi
 """
 
 from __future__ import absolute_import, division, print_function
-from NuRadioMC.utilities import units
+from NuRadioReco.utilities import units
 from NuRadioMC.EvtGen.generator import generate_eventlist_cylinder
 import numpy as np
 import os

--- a/NuRadioReco/examples/PhasedArray/SNR_curves/T01generate_event_list.py
+++ b/NuRadioReco/examples/PhasedArray/SNR_curves/T01generate_event_list.py
@@ -11,7 +11,7 @@ WARNING: This file needs NuRadioMC installed. https://github.com/nu-radio/NuRadi
 """
 
 from __future__ import absolute_import, division, print_function
-from NuRadioMC.utilities import units
+from NuRadioReco.utilities import units
 from NuRadioMC.EvtGen.generator import generate_eventlist_cylinder
 import numpy as np
 import os

--- a/NuRadioReco/examples/PhasedArray/SNR_curves/T02RunSNR.py
+++ b/NuRadioReco/examples/PhasedArray/SNR_curves/T02RunSNR.py
@@ -160,7 +160,8 @@ class mySimulation(simulation.simulation):
                                  triggered_channels=None,  # run trigger on all channels
                                  secondary_channels=[0,1,3,4,6,7], # secondary channels
                                  trigger_name='primary_and_secondary_phasing',
-                                 set_not_triggered=(not self._station.has_triggered("simple_threshold")))
+                                 set_not_triggered=(not self._station.has_triggered("simple_threshold")),
+                                 ref_index=1.78)
 
             if (has_triggered and not reject_event):
                 print('Trigger for SNR', SNRs[iSNR])

--- a/NuRadioReco/modules/ARA/triggerSimulator.py
+++ b/NuRadioReco/modules/ARA/triggerSimulator.py
@@ -260,7 +260,7 @@ class triggerSimulator:
                 trigger_times.append(times[arg_trigger])
 
         has_triggered = False
-        trigger_time_sample = None
+        trigger_time = None
 
         trace_times = station.get_channel(0).get_times()
         trigger_times = np.array(trigger_times)
@@ -269,7 +269,7 @@ class triggerSimulator:
         for trace_time in trace_times[slice_left:slice_right]:
             if ( np.sum( np.abs(trace_time-trigger_times) <= coinc_window/2 ) >= number_concidences ):
                 has_triggered = True
-                trigger_time_sample = np.min(trigger_times)
+                trigger_time = np.min(trigger_times)
                 break
 
         trigger = IntegratedPowerTrigger(trigger_name, power_threshold,
@@ -280,13 +280,13 @@ class triggerSimulator:
         if not has_triggered:
             trigger.set_triggered(False)
             logger.info("Station has NOT passed trigger")
-            trigger_time_sample = 0
-            trigger.set_trigger_time(trigger_time_sample)
+            trigger_time = 0
+            trigger.set_trigger_time(trigger_time)
         else:
             trigger.set_triggered(True)
-            trigger.set_trigger_time(trigger_time_sample)
+            trigger.set_trigger_time(trigger_time)
             logger.info("Station has passed trigger, trigger time is {:.1f} ns (sample {})".format(
-                trigger.get_trigger_time() / units.ns, trigger_time_sample))
+                trigger.get_trigger_time() / units.ns, trigger_time))
 
         station.set_trigger(trigger)
 

--- a/NuRadioReco/modules/ARA/triggerSimulator.py
+++ b/NuRadioReco/modules/ARA/triggerSimulator.py
@@ -264,7 +264,9 @@ class triggerSimulator:
 
         trace_times = station.get_channel(0).get_times()
         trigger_times = np.array(trigger_times)
-        for trace_time in trace_times:
+        slice_left = int(coinc_window/2/(trace_times[1]-trace_times[0]))
+        slice_right = len(trace_times)-slice_left
+        for trace_time in trace_times[slice_left:slice_right]:
             if ( np.sum( np.abs(trace_time-trigger_times) <= coinc_window/2 ) >= number_concidences ):
                 has_triggered = True
                 trigger_time_sample = np.min(trigger_times)

--- a/NuRadioReco/modules/ARA/triggerSimulator.py
+++ b/NuRadioReco/modules/ARA/triggerSimulator.py
@@ -256,7 +256,7 @@ class triggerSimulator:
             if trigger[channel_id]:
                 times = channel.get_times()
                 trace_after_diode = self.tunnel_diode(channel)
-                arg_trigger = np.argwhere( trace_after_diode == np.min(trace_after_diode) )[0,0]
+                arg_trigger = np.argmin(trace_after_diode)
                 trigger_times.append(times[arg_trigger])
 
         has_triggered = False

--- a/NuRadioReco/modules/ARA/triggerSimulator.py
+++ b/NuRadioReco/modules/ARA/triggerSimulator.py
@@ -184,11 +184,11 @@ class triggerSimulator:
             # than taken the full ARA signal chain
             noise = NuRadioReco.framework.channel.Channel(0)
 
-            long_noise = channelGenericNoiseAdder().bandlimited_noise(min_freq=130 * units.MHz,
-                                            max_freq=1500 * units.MHz,
+            long_noise = channelGenericNoiseAdder().bandlimited_noise(min_freq=50 * units.MHz,
+                                            max_freq=1000 * units.MHz,
                                             n_samples=10000,
                                             sampling_rate=channel.get_sampling_rate(),
-                                            amplitude=16.70*units.microvolt,
+                                            amplitude=20 * units.mV,
                                             type='perfect_white')
 
             noise.set_trace(long_noise, channel.get_sampling_rate())

--- a/NuRadioReco/modules/ARA/triggerSimulator.py
+++ b/NuRadioReco/modules/ARA/triggerSimulator.py
@@ -262,7 +262,17 @@ class triggerSimulator:
         has_triggered = False
         trigger_time = None
 
-        trace_times = station.get_channel(0).get_times()
+        times_min = []
+        times_max = []
+        sampling_rates = []
+        for channel in station.iter_channels():
+            times_min.append(np.min(channel.get_times()))
+            times_max.append(np.max(channel.get_times()))
+            sampling_rates.append(channel.get_sampling_rate())
+
+        trace_times = np.arange(np.min(times_min), np.max(times_max),
+                                1/np.min(sampling_rates))
+
         trigger_times = np.array(trigger_times)
         slice_left = int(coinc_window/2/(trace_times[1]-trace_times[0]))
         slice_right = len(trace_times)-slice_left

--- a/NuRadioReco/modules/phasedarray/triggerSimulator.py
+++ b/NuRadioReco/modules/phasedarray/triggerSimulator.py
@@ -231,11 +231,9 @@ class triggerSimulator:
             beam_rolls = self.get_beam_rolls(station, det, triggered_channels, phasing_angles, ref_index=ref_index)
             empty_rolls = [ {} for direction in range(len(phasing_angles)) ]
             logger.debug("secondary_channels:", secondary_channels)
-
             if (len(secondary_channels) == 0):
                 only_primary = True
             else:
-                only_primary = False
                 secondary_beam_rolls = self.get_beam_rolls(station, det, secondary_channels, secondary_phasing_angles, ref_index=ref_index)
 
             if only_primary:

--- a/NuRadioReco/modules/phasedarray/triggerSimulator.py
+++ b/NuRadioReco/modules/phasedarray/triggerSimulator.py
@@ -234,6 +234,7 @@ class triggerSimulator:
             if (len(secondary_channels) == 0):
                 only_primary = True
             else:
+                only_primary = False
                 secondary_beam_rolls = self.get_beam_rolls(station, det, secondary_channels, secondary_phasing_angles, ref_index=ref_index)
 
             if only_primary:

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,5 +20,6 @@ Detector description can be stored in .nur files
 bugfixes:
 -Fixes increase in filesize caused by switch to python3
 -Fixed bug when using no secondary channels on the phased array
+-Fixed bug when using ARA trigger
 
 version 1.0.0 - 2019/08/30 - first python 3 release


### PR DESCRIPTION
While the tunnel diode implementation seems to work just fine, the diode trigger for each channel was later ignored when calculating the coincidences. I've implemented a simpler method for calculating the coincidences - the code takes the minimum of the diode-filtered trace and stores the corresponding time as the trigger time. Then, using a sliding window, it checks if a requested number of coincidences lies in that window. I've also added a new method for the trigger class that calculates the threshold parameters power_mean and power_std using the bandwidth and noise RMS as input.