### PR TITLE
Removes an obsolete function from the station class

### DIFF
--- a/NuRadioReco/framework/station.py
+++ b/NuRadioReco/framework/station.py
@@ -71,15 +71,6 @@ class Station(NuRadioReco.framework.base_station.BaseStation):
             from radiotools import helper
             return helper.get_magnetic_field_vector('arianna')
 
-    def get_trace_vBvvB(self):
-        from radiotools import coordinatesystems
-        zenith = self.get_parameter("zenith")
-        azimuth = self.get_parameter("azimuth")
-        magnetic_field_vector = self.get_magnetic_field_vector()
-        cs = coordinatesystems.cstrafo(zenith, azimuth, magnetic_field_vector)
-        temp_trace = cs.transform_from_onsky_to_ground(self.get_trace())
-        return cs.transform_to_vxB_vxvxB(temp_trace)
-
     def serialize(self, mode):
         base_station_pkl = NuRadioReco.framework.base_station.BaseStation.serialize(self, mode)
         channels_pkl = []


### PR DESCRIPTION
Removes the get_trace_vBvvB method from the station class. Since traces are no longer stored in the station, this method does not make any sense.