### PR TITLE
Fix phased noise

### DIFF
--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedARA.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedARA.py
@@ -41,6 +41,8 @@ channelBandPassFilter = NuRadioReco.modules.channelBandPassFilter.channelBandPas
 channelGenericNoiseAdder = NuRadioReco.modules.channelGenericNoiseAdder.channelGenericNoiseAdder()
 thresholdSimulator = NuRadioReco.modules.trigger.simpleThreshold.triggerSimulator()
 
+edge_around_max = 20 * units.ns
+
 class mySimulation(simulation.simulation):
 
     def _detector_simulation(self):

--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedARA.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedARA.py
@@ -85,6 +85,10 @@ class mySimulation(simulation.simulation):
             max_freq = 0.5 / self._dt
             norm = self._get_noise_normalization(self._station.get_id())  # assuming the same noise level for all stations
             Vrms = self._Vrms / (norm / (max_freq)) ** 0.5  # normalize noise level to the bandwidth its generated for
+<<<<<<< HEAD
+=======
+
+>>>>>>> Fix generic noise adder
             channelGenericNoiseAdder.run(self._evt, self._station, self._det, amplitude=Vrms, min_freq=0 * units.MHz,
                                          max_freq=max_freq, type='rayleigh')
 

--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedARA.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedARA.py
@@ -60,14 +60,22 @@ class mySimulation(simulation.simulation):
                                  number_concidences=1,
                                  trigger_name='simple_threshold')
 
+        max_times = []
+
         # Bool for checking the noise triggering rate
-        check_only_noise = False
-        if check_only_noise:
+        check_only_noise = True
 
-            for channel in self._station.iter_channels():  # loop over all channels (i.e. antennas) of the station
+        for channel in self._station.iter_channels():  # loop over all channels (i.e. antennas) of the station
 
+            times = channel.get_times()
+            argmax = np.argmax( np.abs(channel.get_trace()) )
+            max_times.append(times[argmax])
+            if check_only_noise:
                 trace = channel.get_trace() * 0
                 channel.set_trace(trace, sampling_rate = new_sampling_rate)
+
+        left_time = np.min(max_times) - edge_around_max
+        right_time = np.max(max_times) + edge_around_max
 
         noise = True
 
@@ -77,11 +85,24 @@ class mySimulation(simulation.simulation):
             Vrms = self._Vrms / (norm / (max_freq)) ** 0.5  # normalize noise level to the bandwidth its generated for
             channelGenericNoiseAdder.run(self._evt, self._station, self._det, amplitude=Vrms, min_freq=0 * units.MHz,
                                          max_freq=max_freq, type='rayleigh')
+
         # bandpass filter trace, the upper bound is higher then the sampling rate which makes it just a highpass filter
         channelBandPassFilter.run(self._evt, self._station, self._det, passband=[130 * units.MHz, 1000 * units.GHz],
-                                  filter_type='butter', order=2)
+                                  filter_type='butter', order=6)
         channelBandPassFilter.run(self._evt, self._station, self._det, passband=[0, 750 * units.MHz],
                                   filter_type='butter', order=10)
+
+        # Setting the trace values far from the amplitude maxima to zero
+        # to reduce the noise trigger rate
+        for channel in self._station.iter_channels():
+
+            times = channel.get_times()
+            left_bin = np.argmin(np.abs(times-left_time))
+            right_bin = np.argmin(np.abs(times-right_time))
+            trace = channel.get_trace()
+            trace[0:left_bin] = 0
+            trace[right_bin:None] = 0
+            channel.set_trace(trace, sampling_rate = new_sampling_rate)
 
         # first run a simple threshold trigger
         triggerSimulator.run(self._evt, self._station, self._det,

--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedARA.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedARA.py
@@ -41,7 +41,8 @@ channelBandPassFilter = NuRadioReco.modules.channelBandPassFilter.channelBandPas
 channelGenericNoiseAdder = NuRadioReco.modules.channelGenericNoiseAdder.channelGenericNoiseAdder()
 thresholdSimulator = NuRadioReco.modules.trigger.simpleThreshold.triggerSimulator()
 
-edge_around_max = 20 * units.ns
+left_edge_around_max = 20 * units.ns
+right_edge_around_max = 40 * units.ns
 
 class mySimulation(simulation.simulation):
 
@@ -76,8 +77,8 @@ class mySimulation(simulation.simulation):
                 trace = channel.get_trace() * 0
                 channel.set_trace(trace, sampling_rate = new_sampling_rate)
 
-        left_time = np.min(max_times) - edge_around_max
-        right_time = np.max(max_times) + edge_around_max
+        left_time = np.min(max_times) - left_edge_around_max
+        right_time = np.max(max_times) + right_edge_around_max
 
         noise = True
 

--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedARA.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedARA.py
@@ -63,7 +63,7 @@ class mySimulation(simulation.simulation):
         max_times = []
 
         # Bool for checking the noise triggering rate
-        check_only_noise = True
+        check_only_noise = False
 
         for channel in self._station.iter_channels():  # loop over all channels (i.e. antennas) of the station
 

--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedARA.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedARA.py
@@ -85,10 +85,6 @@ class mySimulation(simulation.simulation):
             max_freq = 0.5 / self._dt
             norm = self._get_noise_normalization(self._station.get_id())  # assuming the same noise level for all stations
             Vrms = self._Vrms / (norm / (max_freq)) ** 0.5  # normalize noise level to the bandwidth its generated for
-<<<<<<< HEAD
-=======
-
->>>>>>> Fix generic noise adder
             channelGenericNoiseAdder.run(self._evt, self._station, self._det, amplitude=Vrms, min_freq=0 * units.MHz,
                                          max_freq=max_freq, type='rayleigh')
 

--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedRNO.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedRNO.py
@@ -67,7 +67,7 @@ class mySimulation(simulation.simulation):
         max_times = []
 
         # Bool for checking the noise triggering rate
-        check_only_noise = True
+        check_only_noise = False
 
         for channel in self._station.iter_channels():  # loop over all channels (i.e. antennas) of the station
 

--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedRNO.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedRNO.py
@@ -70,7 +70,7 @@ class mySimulation(simulation.simulation):
         max_times = []
 
         # Bool for checking the noise triggering rate
-        check_only_noise = True
+        check_only_noise = False
 
         for channel in self._station.iter_channels():  # loop over all channels (i.e. antennas) of the station
 

--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedRNO.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedRNO.py
@@ -45,6 +45,8 @@ main_low_angle = -50 * units.deg
 main_high_angle = 50 * units.deg
 phasing_angles = np.arcsin( np.linspace( np.sin(main_low_angle), np.sin(main_high_angle), 30) )
 
+edge_around_max = 20 * units.ns
+
 class mySimulation(simulation.simulation):
 
     def _detector_simulation(self):

--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedRNO.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedRNO.py
@@ -64,14 +64,22 @@ class mySimulation(simulation.simulation):
                                  number_concidences=1,
                                  trigger_name='simple_threshold')
 
+        max_times = []
+
         # Bool for checking the noise triggering rate
-        check_only_noise = False
-        if check_only_noise:
+        check_only_noise = True
 
-            for channel in self._station.iter_channels():  # loop over all channels (i.e. antennas) of the station
+        for channel in self._station.iter_channels():  # loop over all channels (i.e. antennas) of the station
 
+            times = channel.get_times()
+            argmax = np.argmax( np.abs(channel.get_trace()) )
+            max_times.append(times[argmax])
+            if check_only_noise:
                 trace = channel.get_trace() * 0
                 channel.set_trace(trace, sampling_rate = new_sampling_rate)
+
+        left_time = np.min(max_times) - edge_around_max
+        right_time = np.max(max_times) + edge_around_max
 
         noise = True
 
@@ -81,15 +89,28 @@ class mySimulation(simulation.simulation):
             Vrms = self._Vrms / (norm / (max_freq)) ** 0.5  # normalize noise level to the bandwidth its generated for
             channelGenericNoiseAdder.run(self._evt, self._station, self._det, amplitude=Vrms, min_freq=0 * units.MHz,
                                          max_freq=max_freq, type='rayleigh')
+                                         
         # bandpass filter trace, the upper bound is higher then the sampling rate which makes it just a highpass filter
-        channelBandPassFilter.run(self._evt, self._station, self._det, passband=[130 * units.MHz, 1000 * units.GHz],
-                                  filter_type='butter', order=2)
-        channelBandPassFilter.run(self._evt, self._station, self._det, passband=[0, 1500 * units.MHz],
+        channelBandPassFilter.run(self._evt, self._station, self._det, passband=[132 * units.MHz, 1150 * units.MHz],
+                                  filter_type='butter', order=6)
+        channelBandPassFilter.run(self._evt, self._station, self._det, passband=[0, 700 * units.MHz],
                                   filter_type='butter', order=10)
+
+        # Setting the trace values far from the amplitude maxima to zero
+        # to reduce the noise trigger rate
+        for channel in self._station.iter_channels():
+
+            times = channel.get_times()
+            left_bin = np.argmin(np.abs(times-left_time))
+            right_bin = np.argmin(np.abs(times-right_time))
+            trace = channel.get_trace()
+            trace[0:left_bin] = 0
+            trace[right_bin:None] = 0
+            channel.set_trace(trace, sampling_rate = new_sampling_rate)
 
         # first run a simple threshold trigger
         triggerSimulator.run(self._evt, self._station, self._det,
-                             threshold=1.85 * self._Vrms, # see phased trigger module for explanation
+                             threshold=2.3 * self._Vrms, # see phased trigger module for explanation
                              triggered_channels=None,  # run trigger on all channels
                              trigger_name='primary_and_secondary_phasing', # the name of the trigger
                              phasing_angles=phasing_angles,

--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedRNO.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedRNO.py
@@ -45,6 +45,8 @@ main_low_angle = -50 * units.deg
 main_high_angle = 50 * units.deg
 phasing_angles = np.arcsin( np.linspace( np.sin(main_low_angle), np.sin(main_high_angle), 30) )
 
+edge_around_max = 20 * units.ns
+
 class mySimulation(simulation.simulation):
 
     def _detector_simulation(self):
@@ -89,7 +91,7 @@ class mySimulation(simulation.simulation):
             Vrms = self._Vrms / (norm / (max_freq)) ** 0.5  # normalize noise level to the bandwidth its generated for
             channelGenericNoiseAdder.run(self._evt, self._station, self._det, amplitude=Vrms, min_freq=0 * units.MHz,
                                          max_freq=max_freq, type='rayleigh')
-                                         
+
         # bandpass filter trace, the upper bound is higher then the sampling rate which makes it just a highpass filter
         channelBandPassFilter.run(self._evt, self._station, self._det, passband=[132 * units.MHz, 1150 * units.MHz],
                                   filter_type='butter', order=6)

--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedRNO.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedRNO.py
@@ -45,7 +45,8 @@ main_low_angle = -50 * units.deg
 main_high_angle = 50 * units.deg
 phasing_angles = np.arcsin( np.linspace( np.sin(main_low_angle), np.sin(main_high_angle), 30) )
 
-edge_around_max = 20 * units.ns
+left_edge_around_max = 20 * units.ns
+right_edge_around_max = 40 * units.ns
 
 class mySimulation(simulation.simulation):
 
@@ -80,8 +81,8 @@ class mySimulation(simulation.simulation):
                 trace = channel.get_trace() * 0
                 channel.set_trace(trace, sampling_rate = new_sampling_rate)
 
-        left_time = np.min(max_times) - edge_around_max
-        right_time = np.max(max_times) + edge_around_max
+        left_time = np.min(max_times) - left_edge_around_max
+        right_time = np.max(max_times) + right_edge_around_max
 
         noise = True
 

--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedRNO.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T02RunPhasedRNO.py
@@ -45,8 +45,6 @@ main_low_angle = -50 * units.deg
 main_high_angle = 50 * units.deg
 phasing_angles = np.arcsin( np.linspace( np.sin(main_low_angle), np.sin(main_high_angle), 30) )
 
-edge_around_max = 20 * units.ns
-
 class mySimulation(simulation.simulation):
 
     def _detector_simulation(self):
@@ -69,7 +67,7 @@ class mySimulation(simulation.simulation):
         max_times = []
 
         # Bool for checking the noise triggering rate
-        check_only_noise = False
+        check_only_noise = True
 
         for channel in self._station.iter_channels():  # loop over all channels (i.e. antennas) of the station
 

--- a/NuRadioReco/examples/PhasedArray/Effective_volume/config_RNO.yaml
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/config_RNO.yaml
@@ -1,2 +1,6 @@
 
+propagation:
+  ice_model: greenland_simple
+  attenuation_model: GL1
+
 noise: True

--- a/NuRadioReco/examples/PhasedArray/Noise_trigger_rate/noise_trigger_rate.py
+++ b/NuRadioReco/examples/PhasedArray/Noise_trigger_rate/noise_trigger_rate.py
@@ -67,14 +67,12 @@ if (array_type == 'ARA'):
     primary_angles = default_angles
     secondary_angles = default_sec_angles
 elif (array_type == 'RNO'):
-    min_freq = 130*units.MHz
-    max_freq = 1500*units.MHz
+    min_freq = 132*units.MHz
+    max_freq = 700*units.MHz
     sampling_rate = 3*units.GHz
     window_width = 32
     only_primary = True
     primary_angles = np.arcsin( np.linspace( np.sin(main_low_angle), np.sin(main_high_angle), 30) )
-    secondary_angles = 0.5*(primary_angles[:-1]+primary_angles[1:])
-    secondary_angles = np.insert(secondary_angles, len(secondary_angles), primary_angles[-1] + 1.75*units.deg)
 
 n_samples = 1000000 # number of samples
 time_step = 1./sampling_rate
@@ -83,8 +81,7 @@ amplitude = (300 * 50 * constants.k * bandwidth / units.Hz) ** 0.5
 
 Ntries = args.ntries # number of tries
 
-# threshold_factors = [2.5, 2.45, 2.4]
-threshold_factors = [1.8, 1.85, 1.9, 1.95, 2.0]
+threshold_factors = [2.1, 2.15, 2.20, 2.25, 2.3]
 
 ratios = []
 

--- a/NuRadioReco/framework/trigger.py
+++ b/NuRadioReco/framework/trigger.py
@@ -162,7 +162,8 @@ class SimpleThresholdTrigger(Trigger):
 class SimplePhasedTrigger(Trigger):
 
     def __init__(self, name, threshold, channels=None, secondary_channels=None,
-                 primary_angles=None, secondary_angles=None):
+                 primary_angles=None, secondary_angles=None,
+                 trigger_delays=None, sec_trigger_delays=None):
         """
         initialize trigger class
         Parameters
@@ -180,6 +181,12 @@ class SimplePhasedTrigger(Trigger):
             the angles for each subbeam of the primary phasing
         secondary_angles: array of floats or None
             the angles for each subbeam of the secondary phasing
+        trigger_delays: dictionary
+            the delays for the primary channels that have caused a trigger.
+            If there is no trigger, it's an empty dictionary
+        sec_trigger_delays: dictionary
+            the delays for the secondary channels that have caused a trigger.
+            If there is no trigger or no secondary channels, it's an empty dictionary
         """
         Trigger.__init__(self, name, channels, 'simple_phased')
         self._primary_channels = channels
@@ -187,7 +194,8 @@ class SimplePhasedTrigger(Trigger):
         self._secondary_channels = secondary_channels
         self._secondary_angles = secondary_angles
         self._threshold = threshold
-
+        self._trigger_delays = None
+        self._sec_trigger_delays = None
 
 class HighLowTrigger(Trigger):
 

--- a/NuRadioReco/modules/phasedarray/triggerSimulator.py
+++ b/NuRadioReco/modules/phasedarray/triggerSimulator.py
@@ -112,6 +112,12 @@ class triggerSimulator:
         -------
         is_triggered: bool
             True if the triggering condition is met
+        trigger_delays: dictionary
+            the delays for the primary channels that have caused a trigger.
+            If there is no trigger, it's an empty dictionary
+        sec_trigger_delays: dictionary
+            the delays for the secondary channels that have caused a trigger.
+            If there is no trigger or no secondary channels, it's an empty dictionary
         """
         sampling_rate = station.get_channel(0).get_sampling_rate()
         time_step = 1. / sampling_rate
@@ -155,10 +161,16 @@ class triggerSimulator:
             squared_mean = np.sum(windowed_traces ** 2 / window_width, axis=1)
 
             if True in (squared_mean > squared_mean_threshold):
+                trigger_delays = {}
+                for channel_id in subbeam_rolls:
+                    trigger_delays[channel_id] = subbeam_rolls[channel_id] * time_step
+                sec_trigger_delays = {}
+                for channel_id in sec_subbeam_rolls:
+                    sec_trigger_delays[channel_id] = sec_subbeam_rolls[channel_id] * time_step
                 logger.debug("Station has triggered")
-                return True
+                return True, trigger_delays, sec_trigger_delays
 
-        return False
+        return False, {}, {}
 
     @register_run()
     def run(self, evt, station, det,
@@ -224,6 +236,8 @@ class triggerSimulator:
         if set_not_triggered:
 
             is_triggered = False
+            trigger_delays = np.array([])
+            sec_trigger_delays = np.array([])
 
         else:
 
@@ -238,15 +252,19 @@ class triggerSimulator:
                 secondary_beam_rolls = self.get_beam_rolls(station, det, secondary_channels, secondary_phasing_angles, ref_index=ref_index)
 
             if only_primary:
-                is_triggered = self.phased_trigger(station, beam_rolls, empty_rolls, triggered_channels, threshold, window_time)
+                is_triggered, trigger_delays, sec_trigger_delays = self.phased_trigger(station,
+                            beam_rolls, empty_rolls, triggered_channels, threshold, window_time)
             elif coupled:
-                is_triggered = self.phased_trigger(station, beam_rolls, secondary_beam_rolls, triggered_channels, threshold, window_time)
+                is_triggered, trigger_delays, sec_trigger_delays = self.phased_trigger(station,
+                            beam_rolls, secondary_beam_rolls, triggered_channels, threshold, window_time)
             else:
-                primary_trigger = self.phased_trigger(station, beam_rolls, empty_rolls, triggered_channels, threshold, window_time)
-                secondary_trigger = self.phased_trigger(station, secondary_beam_rolls, empty_rolls, secondary_channels, threshold, window_time)
+                primary_trigger, trigger_delays, dummy_delays = self.phased_trigger(station, beam_rolls, empty_rolls, triggered_channels, threshold, window_time)
+                secondary_trigger, sec_trigger_delays, dummy_delays = self.phased_trigger(station, secondary_beam_rolls, empty_rolls, secondary_channels, threshold, window_time)
                 is_triggered = primary_trigger or secondary_trigger
 
-        trigger = SimplePhasedTrigger(trigger_name, threshold, triggered_channels, secondary_channels, phasing_angles, secondary_phasing_angles)
+        trigger = SimplePhasedTrigger(trigger_name, threshold, triggered_channels, secondary_channels,
+                                      phasing_angles, secondary_phasing_angles,
+                                      trigger_delays, sec_trigger_delays)
         trigger.set_triggered(is_triggered)
         station.set_trigger(trigger)
 

--- a/NuRadioReco/modules/phasedarray/triggerSimulator.py
+++ b/NuRadioReco/modules/phasedarray/triggerSimulator.py
@@ -236,8 +236,8 @@ class triggerSimulator:
         if set_not_triggered:
 
             is_triggered = False
-            trigger_delays = np.array([])
-            sec_trigger_delays = np.array([])
+            trigger_delays = {}
+            sec_trigger_delays = {}
 
         else:
 


### PR DESCRIPTION
It turns out that with the new proper noise normalisation, the noise-triggered events are more than what I'm comfortable with. I've modified the phased array examples to show how to create an acceptance window around the actual electric field, so that we don't consider the part of the traces which is only noise and we have fewer noise-triggered events as a consequence. I'm going to post some plots as soon as they're ready. I've also changed the bandwidth to the one we will actually use for Greenland and changed the order of one of the filters.

I thought about implementing this window inside the trigger module, but that's perhaps a bit too cumbersome. It would require the module to know either the noiseless traces and the noisy traces, or to restrict the traces to a user-defined window, which is more or less the same the new steering files do. I don't know what would be the best course of action here.