### PR TITLE
Revert "remove unused arguments of bandpassfilter module"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_script:
   - unzip /tmp/radiotools.zip
   - mv radiotools-master radiotools
   - export PYTHONPATH=$PWD/radiotools
-  - wget https://github.com/nu-radio/NuRadioMC/archive/fix-arguments_bandpathfilter.zip -O /tmp/NuRadioMC.zip
+  - wget https://github.com/nu-radio/NuRadioMC/archive/master.zip -O /tmp/NuRadioMC.zip
   - unzip /tmp/NuRadioMC.zip
-  - mv NuRadioMC-fix-arguments_bandpathfilter NuRadioMC
+  - mv NuRadioMC-master NuRadioMC
   - export PYTHONPATH=$PYTHONPATH:$PWD/NuRadioMC
   - export PYTHONPATH=$PYTHONPATH:$PWD
   - wget http://arianna.ps.uci.edu/~arianna/data/AntennaModels/createLPDA_100MHz_InfFirn/createLPDA_100MHz_InfFirn.pkl

--- a/NuRadioReco/examples/PhasedArray/Effective_volume/T01generate_event_list.py
+++ b/NuRadioReco/examples/PhasedArray/Effective_volume/T01generate_event_list.py
@@ -19,7 +19,7 @@ import numpy as np
 import os
 import sys
 
-if (len(sys.argv) < 2):
+if ( len(sys.argv) < 2 ):
 	mode = 'simple'
 else:
 	mode = sys.argv[1]
@@ -30,9 +30,9 @@ zmax = 0 * units.km
 rmin = 0 * units.km
 rmax = 4 * units.km
 
-costhetas = np.linspace(1, -1, 2)  # Usually 20
+costhetas = np.linspace(1, -1, 2) # Usually 20
 thetas = np.arccos(costhetas)
-# thetas = np.linspace(0.*units.deg, 180.*units.deg, 3)
+#thetas = np.linspace(0.*units.deg, 180.*units.deg, 3)
 thetamins = thetas[0:-1]
 thetamaxs = thetas[1:]
 print(thetamins)
@@ -41,16 +41,16 @@ print(thetamaxs)
 phimin = 0.*units.deg
 phimax = 360.*units.deg
 
-if (mode == 'full'):
-	logEs = np.linspace(15., 20., 50)  # Usually 50
+if ( mode == 'full' ):
+	logEs = np.linspace(15., 20., 50) # Usually 50
 else:
 	logEs = np.linspace(16., 19, 2)
-Es = 10 ** logEs * units.eV
+Es = 10**logEs * units.eV
 Emins = Es[0:-1]
 Emaxs = Es[1:]
 
-flavours = [12]  # +/-12: electronic neutrino. +/-14: muonic neutrino. +/-16: tau neutrino
-if (mode == 'full'):
+flavours = [12] # +/-12: electronic neutrino. +/-14: muonic neutrino. +/-16: tau neutrino
+if ( mode == 'full' ):
 	nevt = 1e6
 	nevt_perfile = 1e5
 elif mode == 'minimal':
@@ -64,15 +64,15 @@ for thetamin, thetamax in zip(thetamins, thetamaxs):
 
 	for flavour in flavours:
 
-		folder_angle = "{:.2f}rad_{}".format(thetamin, flavour)
+		folder_angle = "{:.2f}rad_{}".format(thetamin,flavour)
 		try:
 			os.mkdir(folder_angle)
 		except:
 			pass
 
 		folderlist = []
-		for ifolder, Emin, Emax in zip(range(len(Emins)), Emins, Emaxs):
-			folderlist.append("{:.2f}_{}_{}_{:.2e}_{:.2e}".format(thetamin, flavour, str(ifolder).zfill(2), Emin, Emax))
+		for ifolder, Emin,Emax in zip(range(len(Emins)),Emins,Emaxs):
+			folderlist.append("{:.2f}_{}_{}_{:.2e}_{:.2e}".format(thetamin,flavour,str(ifolder).zfill(2),Emin,Emax))
 		for folder in folderlist:
 			try:
 				os.mkdir(os.path.join(folder_angle, folder))
@@ -87,20 +87,20 @@ for thetamin, thetamax in zip(thetamins, thetamaxs):
 			except:
 				pass
 			if mode == 'simple':
-				outname = folder + '.hdf5'
+				outname = folder+'.hdf5'
 			elif mode == 'minimal':
 				outname = 'minimal_eventlist.hdf5'
 			else:
-				outname = folder_angle + '/' + folder + '/input/' + folder + '.hdf5'
-			print(Emin / units.PeV, Emax / units.PeV)
+				outname = folder_angle+'/'+folder+'/input/'+folder+'.hdf5'
+			print(Emin/units.PeV, Emax/units.PeV)
 			print(outname)
 			generate_eventlist_cylinder(outname, nevt, Emin, Emax, rmin, rmax, zmin, zmax, full_rmin=rmin, full_rmax=rmax, full_zmin=zmin, full_zmax=zmax, thetamin=thetamin, thetamax=thetamax, phimin=phimin, phimax=phimax, start_event_id=1, flavor=[flavour], n_events_per_file=nevt_perfile, deposited=True)
 
 # generate one event list at 1e19 eV with 100 neutrinos
-# generate_eventlist_cylinder('1e19_n1e2.hdf5', 1e2, 1e19 * units.eV, 1e19 * units.eV, rmin, rmax, zmin, zmax)
+#generate_eventlist_cylinder('1e19_n1e2.hdf5', 1e2, 1e19 * units.eV, 1e19 * units.eV, rmin, rmax, zmin, zmax)
 
 # generate one event list at 1e19 eV with 1000 neutrinos
-# generate_eventlist_cylinder('1e19_n1e3.hdf5', 1e3, 1e19 * units.eV, 1e19 * units.eV, rmin, rmax, zmin, zmax)
+#generate_eventlist_cylinder('1e19_n1e3.hdf5', 1e3, 1e19 * units.eV, 1e19 * units.eV, rmin, rmax, zmin, zmax)
 
 # generate one event list at 1e18 eV with 10000 neutrinos
-# generate_eventlist_cylinder('1e18_n1e4.hdf5', 1e4, 1e18 * units.eV, 1e18 * units.eV, rmin, rmax, zmin, zmax)
+#generate_eventlist_cylinder('1e18_n1e4.hdf5', 1e4, 1e18 * units.eV, 1e18 * units.eV, rmin, rmax, zmin, zmax)

--- a/NuRadioReco/examples/PhasedArray/SNR_curves/T01generate_event_list.py
+++ b/NuRadioReco/examples/PhasedArray/SNR_curves/T01generate_event_list.py
@@ -19,40 +19,40 @@ import os
 z12 = -200 * units.m
 rho = 500 * units.m
 
-obs_angles = np.linspace(-10., 10., 41) * units.deg
+obs_angles = np.linspace(-10.,10.,41) * units.deg
 # Elevation of the vertex point seen from the middle point of the array
 
 for obs_angle in obs_angles:
 	# define simulation volume
-	zmin = z12 + rho * np.tan(obs_angle) - 0.1 * units.m
-	zmax = z12 + rho * np.tan(obs_angle)
+	zmin = z12 + rho*np.tan(obs_angle) - 0.1 * units.m
+	zmax = z12 + rho*np.tan(obs_angle)
 	rmin = rho
 	rmax = rho + 0.1 * units.m
 	print('Neutrino height', zmax)
 
 	theta_c = 55 * units.deg
-	theta_nu = 90 * units.deg - theta_c - obs_angle
+	theta_nu = 90*units.deg - theta_c - obs_angle
 
 	phimin = 0.*units.deg
-	phimax = 0.1 * units.deg
+	phimax = 0.1*units.deg
 
 	if (theta_nu < 0):
 		theta_nu = -theta_nu
-		phimin = 180 * units.deg
-		phimax = 180.1 * units.deg
+		phimin = 180*units.deg
+		phimax = 180.1*units.deg
 
-	thetas = np.array([theta_nu, theta_nu + 0.01 * units.deg])
+	thetas = np.array([theta_nu, theta_nu + 0.01*units.deg])
 	thetamins = thetas[0:-1]
 	thetamaxs = thetas[1:]
 	print(thetamins)
 	print(thetamaxs)
 
-	Es = np.array([18, 18.1])
-	Es = 10 ** Es
+	Es = np.array([18,18.1])
+	Es = 10**Es
 	Emins = Es[0:-1]
 	Emaxs = Es[1:]
 
-	flavours = [12]  # no difference between neutrinos and antineutrinos for us
+	flavours = [12] # no difference between neutrinos and antineutrinos for us
 
 	nevt = 2e3
 	nevt_perfile = 1e3
@@ -61,15 +61,15 @@ for obs_angle in obs_angles:
 
 		for flavour in flavours:
 
-			folder_angle = "{:.1f}deg_{}".format(thetamin / units.deg, flavour)
+			folder_angle = "{:.1f}deg_{}".format(thetamin/units.deg,flavour)
 			try:
 				os.mkdir(folder_angle)
 			except:
 				pass
 
 			folderlist = []
-			for ifolder, Emin, Emax in zip(range(len(Emins)), Emins, Emaxs):
-				folderlist.append("{:.2f}_{}_{}_{:.2e}_{:.2e}".format(thetamin / units.deg, flavour, str(ifolder).zfill(2), Emin, Emax))
+			for ifolder, Emin,Emax in zip(range(len(Emins)),Emins,Emaxs):
+				folderlist.append("{:.2f}_{}_{}_{:.2e}_{:.2e}".format(thetamin/units.deg,flavour,str(ifolder).zfill(2),Emin,Emax))
 			for folder in folderlist:
 				try:
 					os.mkdir(os.path.join(folder_angle, folder))
@@ -83,7 +83,7 @@ for obs_angle in obs_angles:
 					os.mkdir(input_dir)
 				except:
 					pass
-				outname = folder_angle + '/' + folder + '/input/' + folder + '.hdf5'
-				print(Emin / units.PeV, Emax / units.PeV)
+				outname = folder_angle+'/'+folder+'/input/'+folder+'.hdf5'
+				print(Emin/units.PeV, Emax/units.PeV)
 				print(outname)
 				generate_eventlist_cylinder(outname, nevt, Emin, Emax, rmin, rmax, zmin, zmax, full_rmin=rmin, full_rmax=rmax, full_zmin=zmin, full_zmax=zmax, thetamin=thetamin, thetamax=thetamax, phimin=phimin, phimax=phimax, start_event_id=1, flavor=[flavour], n_events_per_file=nevt_perfile, deposited=True)

--- a/NuRadioReco/modules/channelBandPassFilter.py
+++ b/NuRadioReco/modules/channelBandPassFilter.py
@@ -65,6 +65,9 @@ class channelBandPassFilter:
     def get_filter(self, frequencies, station_id, channel_id, det, passband, filter_type, order=2):
         """
         helper function to return the filter that the module applies.
+        
+        The unused parameters station_id, channel_id, det are needed to have the same signature as the 
+        `get_filter` functions of other modules, e.g. the hardwareResponseIncorporator. 
 
         Parameters
         -----------

--- a/NuRadioReco/modules/channelBandPassFilter.py
+++ b/NuRadioReco/modules/channelBandPassFilter.py
@@ -62,7 +62,7 @@ class channelBandPassFilter:
         for channel in station.iter_channels():
             self._apply_filter(channel, passband, filter_type, order, False)
 
-    def get_filter(self, frequencies, passband, filter_type, order=2):
+    def get_filter(self, frequencies, station_id, channel_id, det, passband, filter_type, order=2):
         """
         helper function to return the filter that the module applies.
 
@@ -122,11 +122,11 @@ class channelBandPassFilter:
         isFIR = False
 
         if(filter_type == 'rectangular'):
-            trace_fft *= self.get_filter(frequencies, passband, filter_type)
+            trace_fft *= self.get_filter(frequencies, 0, 0, None, passband, filter_type)
         elif(filter_type == 'butter'):
-            trace_fft *= self.get_filter(frequencies, passband, filter_type, order)
+            trace_fft *= self.get_filter(frequencies, 0, 0, None, passband, filter_type, order)
         elif(filter_type == 'butterabs'):
-            trace_fft *= self.get_filter(frequencies, passband, filter_type, order)
+            trace_fft *= self.get_filter(frequencies, 0, 0, None, passband, filter_type, order)
         elif(filter_type.find('FIR') >= 0):
             # print('This is a FIR filter')
             firarray = filter_type.split()
@@ -180,7 +180,7 @@ class channelBandPassFilter:
 #             trace_fft = channel.get_frequency_spectrum()
             isFIR = True
         else:
-            trace_fft *= self.get_filter(frequencies, passband, filter_type)
+            trace_fft *= self.get_filter(frequencies, 0, 0, None, passband, filter_type)
         if isFIR:
             channel.set_trace(trace_fir, sample_rate)
             # print('set trace for fir')


### PR DESCRIPTION
Reverts nu-radio/NuRadioReco#163

The `get_filter` function of the bandpass filter module has the unused parameters `station_id`, `channel_id` and `detector`. However, this is needed because other modules (e.g. `hardwareResponseIncorporator`) need these arguments and we need to have the same syntax in all functions. 