### PR TITLE
Adding copy statements so as not to modify the phased array trace

### DIFF
--- a/NuRadioReco/modules/envelope_phasedarray/triggerSimulator.py
+++ b/NuRadioReco/modules/envelope_phasedarray/triggerSimulator.py
@@ -85,7 +85,7 @@ class triggerSimulator(phasedTrigger):
             channel_id = channel.get_id()
 
             trace = diode.tunnel_diode(channel)  # get the enveloped trace
-            times = channel.get_times()  # get the corresponding time bins
+            times = np.copy(channel.get_times())  # get the corresponding time bins
 
             if cut_times != (None,None):
                 left_bin = np.argmin(np.abs(times-cut_times[0]))

--- a/NuRadioReco/modules/phasedarray/triggerSimulator.py
+++ b/NuRadioReco/modules/phasedarray/triggerSimulator.py
@@ -135,8 +135,8 @@ class triggerSimulator:
         for channel in station.iter_channels(use_channels=triggered_channels):
             channel_id = channel.get_id()
 
-            trace = channel.get_trace()  # get the enveloped trace
-            times = channel.get_times()  # get the corresponding time bins
+            trace = np.copy(channel.get_trace())  # get the enveloped trace
+            times = np.copy(channel.get_times())  # get the corresponding time bins
 
             if cut_times != (None,None):
                 left_bin = np.argmin(np.abs(times-cut_times[0]))


### PR DESCRIPTION
There was a mistake before when treating the cut times for the phased array trace. The trace was fetched from the channel by reference, and not copied, which means that the original channel trace was modified. This was not the case for the envelope phasing, though.

And I also added copy statements for the time arrays, just for the sake of being paranoid.