### PR TITLE
Diode parameters

### DIFF
--- a/NuRadioReco/utilities/diodeSimulator.py
+++ b/NuRadioReco/utilities/diodeSimulator.py
@@ -126,7 +126,8 @@ class diodeSimulator:
                                    max_freq=1*units.GHz,
                                    amplitude=10*units.microvolt,
                                    type='rayleigh',
-                                   n_samples=10000):
+                                   n_tries=1,
+                                   n_samples=int(1e8)):
         """
         Calculates the mean and the standard deviation for the diode-filtered noise.
 
@@ -142,9 +143,11 @@ class diodeSimulator:
             Voltage amplitude (RMS) for the noise
         type: string
             Noise type
-        n_samples: int
+        n_tries: int
             Number of times the calculation is carried out, to get proper
             averages for the mean and the standard deviation.
+        n_samples: int 
+            Number of samples for each individual noise trace
 
         Returns
         -------
@@ -157,16 +160,16 @@ class diodeSimulator:
         power_mean_list = []
         power_std_list = []
 
-        for i_sample in range(n_samples):
+        for i_try in range(n_tries):
 
             noise = NuRadioReco.framework.channel.Channel(0)
 
             long_noise = channelGenericNoiseAdder().bandlimited_noise(min_freq=min_freq,
-                                            max_freq=max_freq,
-                                            n_samples=10000,
-                                            sampling_rate=sampling_rate,
-                                            amplitude=amplitude,
-                                            type=type)
+                                                                      max_freq=max_freq,
+                                                                      n_samples=n_samples,
+                                                                      sampling_rate=sampling_rate,
+                                                                      amplitude=amplitude,
+                                                                      type=type)
 
             noise.set_trace(long_noise, sampling_rate)
             power_noise = self.tunnel_diode(noise)

--- a/NuRadioReco/utilities/diodeSimulator.py
+++ b/NuRadioReco/utilities/diodeSimulator.py
@@ -126,8 +126,8 @@ class diodeSimulator:
                                    max_freq=1*units.GHz,
                                    amplitude=10*units.microvolt,
                                    type='rayleigh',
-                                   n_tries=1,
-                                   n_samples=int(1e8)):
+                                   n_tries=10000,
+                                   n_samples=10000):
         """
         Calculates the mean and the standard deviation for the diode-filtered noise.
 
@@ -146,7 +146,7 @@ class diodeSimulator:
         n_tries: int
             Number of times the calculation is carried out, to get proper
             averages for the mean and the standard deviation.
-        n_samples: int 
+        n_samples: int
             Number of samples for each individual noise trace
 
         Returns

--- a/NuRadioReco/utilities/diodeSimulator.py
+++ b/NuRadioReco/utilities/diodeSimulator.py
@@ -125,7 +125,8 @@ class diodeSimulator:
                                    min_freq=50*units.MHz,
                                    max_freq=1*units.GHz,
                                    amplitude=10*units.microvolt,
-                                   type='rayleigh'):
+                                   type='rayleigh',
+                                   n_samples=10000):
         """
         Calculates the mean and the standard deviation for the diode-filtered noise.
 
@@ -139,9 +140,11 @@ class diodeSimulator:
             Maximum frequency of the bandwidth
         amplitude: float
             Voltage amplitude (RMS) for the noise
-
         type: string
             Noise type
+        n_samples: int
+            Number of times the calculation is carried out, to get proper
+            averages for the mean and the standard deviation.
 
         Returns
         -------
@@ -150,20 +153,29 @@ class diodeSimulator:
         power_std: float
             Standard deviation of the diode-filtered noise
         """
-        noise = NuRadioReco.framework.channel.Channel(0)
 
-        long_noise = channelGenericNoiseAdder().bandlimited_noise(min_freq=min_freq,
-                                        max_freq=max_freq,
-                                        n_samples=10000,
-                                        sampling_rate=sampling_rate,
-                                        amplitude=amplitude,
-                                        type=type)
+        power_mean_list = []
+        power_std_list = []
 
-        noise.set_trace(long_noise, sampling_rate)
-        power_noise = self.tunnel_diode(noise)
+        for i_sample in range(n_samples):
 
-        power_mean = np.mean(power_noise)
-        power_std = np.std(power_noise)
+            noise = NuRadioReco.framework.channel.Channel(0)
+
+            long_noise = channelGenericNoiseAdder().bandlimited_noise(min_freq=min_freq,
+                                            max_freq=max_freq,
+                                            n_samples=10000,
+                                            sampling_rate=sampling_rate,
+                                            amplitude=amplitude,
+                                            type=type)
+
+            noise.set_trace(long_noise, sampling_rate)
+            power_noise = self.tunnel_diode(noise)
+
+            power_mean_list.append(np.mean(power_noise))
+            power_std_list.append(np.std(power_noise))
+
+        power_mean = np.mean(power_mean_list)
+        power_std = np.mean(power_std_list)
 
         return power_mean, power_std
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ new features:
    now also need the sampling rate as an argument.
 -Envelope phased array available
 -Trigger times now include the time with respect to the first interaction (vertex times)
+-Improved calculation of the diode noise parameters
 
 Detector description can be stored in .nur files
 Large overhaul of the event structure. Adds shower classes and hybrid detector information.


### PR DESCRIPTION
I noticed that the noise trigger rate for the envelope phased trigger was highly variable using the same configuration. The problem was that the calculation of the mean and standard deviation of thermal noise after passing through the diode needed more samples to be closer to the actual averages. With this pull request the noise trigger rate becomes more stable.