### PR TITLE
Convert datetime

### DIFF
--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -79,13 +79,14 @@ class BaseStation():
             time_strings = str(time).split(' ')
             self._station_time = astropy.time.Time('{}T{}'.format(time_strings[0], time_strings[1]), format='isot')
         elif isinstance(time, astropy.time.Time):
-            if time.format == 'datetime':
-                print('!!! 2')
-                time_strings = str(time).split(' ')
-                self._station_time = astropy.time.Time('{}T{}'.format(time_strings[0], time_strings[1]), format='isot')
-            else:
-                print('!!! 3')
-                self._station_time = time
+            #if time.format == 'datetime':
+            #    print('!!! 2')
+            #    print(time)
+            #    time_strings = str(time).split(' ')
+            #    self._station_time = astropy.time.Time('{}T{}'.format(time_strings[0], time_strings[1]), format='isot')
+            #else:
+            print('!!! 3')
+            self._station_time = time
         else:
             print('!!! 4')
             self._station_time = time

--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -74,21 +74,11 @@ class BaseStation():
         self._parameters.pop(key, None)
 
     def set_station_time(self, time):
+        print('astropy version is ', astropy.__version__)
         if isinstance(time, datetime.datetime):
-            print('!!! 1')
             time_strings = str(time).split(' ')
             self._station_time = astropy.time.Time('{}T{}'.format(time_strings[0], time_strings[1]), format='isot')
-        elif isinstance(time, astropy.time.Time):
-            #if time.format == 'datetime':
-            #    print('!!! 2')
-            #    print(time)
-            #    time_strings = str(time).split(' ')
-            #    self._station_time = astropy.time.Time('{}T{}'.format(time_strings[0], time_strings[1]), format='isot')
-            #else:
-            print('!!! 3')
-            self._station_time = time
         else:
-            print('!!! 4')
             self._station_time = time
 
     def get_station_time(self):

--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -75,8 +75,19 @@ class BaseStation():
 
     def set_station_time(self, time):
         if isinstance(time, datetime.datetime):
-            self._station_time = astropy.time.Time(time)
+            print('!!! 1')
+            time_strings = str(time).split(' ')
+            self._station_time = astropy.time.Time('{}T{}'.format(time_strings[0], time_strings[1]), format='isot')
+        elif isinstance(time, astropy.time.Time):
+            if time.format == 'datetime':
+                print('!!! 2')
+                time_strings = str(time).split(' ')
+                self._station_time = astropy.time.Time('{}T{}'.format(time_strings[0], time_strings[1]), format='isot')
+            else:
+                print('!!! 3')
+                self._station_time = time
         else:
+            print('!!! 4')
             self._station_time = time
 
     def get_station_time(self):

--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -74,7 +74,6 @@ class BaseStation():
         self._parameters.pop(key, None)
 
     def set_station_time(self, time):
-        print('astropy version is ', astropy.__version__)
         if isinstance(time, datetime.datetime):
             time_strings = str(time).split(' ')
             self._station_time = astropy.time.Time('{}T{}'.format(time_strings[0], time_strings[1]), format='isot')


### PR DESCRIPTION
The way datetime was converted to astropy time breaks with astropy version 4.0. This one works for both 4.0 and 3.0.