### PR TITLE
adapt get_array_of_channels for neutrinos to use refractive index at …

### DIFF
--- a/NuRadioReco/modules/voltageToEfieldConverter.py
+++ b/NuRadioReco/modules/voltageToEfieldConverter.py
@@ -35,8 +35,11 @@ def get_array_of_channels(station, use_channels, det, zenith, azimuth,
         antenna_position = det.get_relative_position(station_id, channel_id)
         # determine refractive index of signal propagation speed between antennas
         refractive_index = ice.get_refractive_index(1, site)  # if signal comes from above, in-air propagation speed
-        if(zenith > 0.5 * np.pi):
-            refractive_index = ice.get_refractive_index(antenna_position[2], site)  # if signal comes from below, use refractivity at antenna position
+        if station.get_sim_station().is_cosmic_ray():
+            if(zenith > 0.5 * np.pi):
+                refractive_index = ice.get_refractive_index(antenna_position[2], site)  # if signal comes from below, use refractivity at antenna position
+        if station.get_sim_station().is_neutrino():
+            refractive_index = ice.get_refractive_index(antenna_position[2], site)
         time_shift = -geo_utl.get_time_delay_from_direction(zenith, azimuth, antenna_position, n=refractive_index)
         t_geos[iCh] = time_shift
         t_cables[iCh] = channel.get_trace_start_time()


### PR DESCRIPTION
…antenna position

change get_array_of channels in voltageToEfieldConverter such that the refractive index is always taken as the one at the antenna positions for neutrinos. For cosmic-rays, this depends on the direction. 

