### PR TITLE
setting antenna model by depth is now optional and can be deactivated

### DIFF
--- a/NuRadioReco/detector/detector.py
+++ b/NuRadioReco/detector/detector.py
@@ -131,7 +131,7 @@ class Detector(object):
     """
 
     def __init__(self, source='json', json_filename='ARIANNA/arianna_detector_db.json',
-                 dictionary=None, assume_inf=True):
+                 dictionary=None, assume_inf=True, antenna_by_depth=True):
         """
         Initialize the stations detector properties.
 
@@ -149,6 +149,10 @@ class Detector(object):
             default value is 'ARIANNA/arianna_detector_db.json'
         assume_inf : Bool
             Default to True, if true forces antenna madels to have infinite boundary conditions, otherwise the antenna madel will be determined by the station geometry.
+        antenna_by_depth: bool (default True)
+            if True the antenna model is determined automatically depending on the depth of the antenna. This is done by 
+            appending e.g. '_InfFirn' to the antenna model name. 
+            if False, the antenna model as specified in the database is used. 
         """
         if(source == 'sql'):
             self._db = buffer_db(in_memory=True)
@@ -192,6 +196,9 @@ class Detector(object):
         self.__current_time = None
 
         self.__assume_inf = assume_inf
+        if antenna_by_depth:
+            logger.info("the correct antenna model will be determined automatically based on the depth of the antenna")
+        self._antenna_by_depth = antenna_by_depth
 
     def __query_channel(self, station_id, channel_id):
         Channel = Query()
@@ -697,22 +704,25 @@ class Detector(object):
         antenna_type = self.get_antenna_type(station_id, channel_id)
         antenna_relative_position = self.get_relative_position(station_id, channel_id)
 
-        antenna_model = ""
-        if(zenith is not None and (antenna_type == 'createLPDA_100MHz')):
-            if(antenna_relative_position[2] > 0):
-                antenna_model = "{}_InfAir".format(antenna_type)
-                if((not self.__assume_inf) and zenith < 90 * units.deg):
-                    antenna_model = "{}_z1cm_InAir_RG".format(antenna_type)
-            else:  # antenna in firn
-                antenna_model = "{}_InfFirn".format(antenna_type)
-                if((not self.__assume_inf) and zenith > 90 * units.deg):  # signal comes from below
-                    antenna_model = "{}_z1cm_InFirn_RG".format(antenna_type)
-                    # we need to add further distinction here
-        elif(not antenna_type.startswith('analytic')):
-            if(antenna_relative_position[2] > 0):
-                antenna_model = "{}_InfAir".format(antenna_type)
+        if self._antenna_by_depth:
+            antenna_model = ""
+            if(zenith is not None and (antenna_type == 'createLPDA_100MHz')):
+                if(antenna_relative_position[2] > 0):
+                    antenna_model = "{}_InfAir".format(antenna_type)
+                    if((not self.__assume_inf) and zenith < 90 * units.deg):
+                        antenna_model = "{}_z1cm_InAir_RG".format(antenna_type)
+                else:  # antenna in firn
+                    antenna_model = "{}_InfFirn".format(antenna_type)
+                    if((not self.__assume_inf) and zenith > 90 * units.deg):  # signal comes from below
+                        antenna_model = "{}_z1cm_InFirn_RG".format(antenna_type)
+                        # we need to add further distinction here
+            elif(not antenna_type.startswith('analytic')):
+                if(antenna_relative_position[2] > 0):
+                    antenna_model = "{}_InfAir".format(antenna_type)
+                else:
+                    antenna_model = "{}_InfFirn".format(antenna_type)
             else:
-                antenna_model = "{}_InfFirn".format(antenna_type)
+                antenna_model = antenna_type
         else:
             antenna_model = antenna_type
         return antenna_model

--- a/NuRadioReco/detector/generic_detector.py
+++ b/NuRadioReco/detector/generic_detector.py
@@ -30,7 +30,9 @@ class GenericDetector(NuRadioReco.detector.detector.Detector):
     therefore not be used for real data, but only for simulation studies.
     This detector only accepts json detector descriptions or dictionary.
     """
-    def __init__(self, json_filename, default_station, default_channel=None, source='json', dictionary=None, assume_inf=True):
+
+    def __init__(self, json_filename, default_station, default_channel=None, source='json', dictionary=None,
+                 assume_inf=True, antenna_by_depth=True):
         """
         Initialize the stations detector properties.
 
@@ -59,9 +61,13 @@ class GenericDetector(NuRadioReco.detector.detector.Detector):
             passed to this parameter will be used for the detector description.
         assume_inf : Bool
             Default to True, if true forces antenna madels to have infinite boundary conditions, otherwise the antenna madel will be determined by the station geometry.
+        antenna_by_depth: bool (default True)
+            if True the antenna model is determined automatically depending on the depth of the antenna. This is done by 
+            appending e.g. '_InfFirn' to the antenna model name. 
+            if False, the antenna model as specified in the database is used. 
         """
-        super(GenericDetector, self).__init__(source, json_filename, dictionary, assume_inf)
-
+        super(GenericDetector, self).__init__(source=source, json_filename=json_filename, dictionary=dictionary,
+                                              assume_inf=assume_inf, antenna_by_depth=antenna_by_depth)
         self.__default_station_id = default_station
         self.__default_channel_id = default_channel
         self.__station_changes_for_event = []
@@ -75,7 +81,7 @@ class GenericDetector(NuRadioReco.detector.detector.Detector):
 
         if default_channel is not None:
             Channel = Query()
-            self.__default_channel = self._channels.get((Channel.station_id == default_station)&(Channel.channel_id == default_channel))
+            self.__default_channel = self._channels.get((Channel.station_id == default_station) & (Channel.channel_id == default_channel))
             if self.__default_channel is None:
                 raise ValueError('The default channel {} of station {} was not found in the detector description'.format(default_channel, self.__default_station_id))
         else:
@@ -210,7 +216,7 @@ class GenericDetector(NuRadioReco.detector.detector.Detector):
                     changes.append(change)
         return changes
 
-    def set_event(self,run_number, event_id):
+    def set_event(self, run_number, event_id):
         """
         Sets the run number and event ID for which the detector description
         should be returned. This is needed if event-specific changes to the


### PR DESCRIPTION
So far the depth of the antenna was used to automatically determine if the antenna is in firn or in air. This PR makes this option optional which is useful for simulation studies. It will be made the default in NuRadioMC