### PR TITLE
Io fix

### DIFF
--- a/NuRadioReco/autodoc/pages/installation.rst
+++ b/NuRadioReco/autodoc/pages/installation.rst
@@ -70,6 +70,7 @@ ______________________
       pip install astropy
 
   - tinydb:
+    tinydb version 4.1.1 or newer is required.
 
     .. code-block:: Bash
 

--- a/NuRadioReco/detector/detector.py
+++ b/NuRadioReco/detector/detector.py
@@ -150,15 +150,15 @@ class Detector(object):
         assume_inf : Bool
             Default to True, if true forces antenna madels to have infinite boundary conditions, otherwise the antenna madel will be determined by the station geometry.
         antenna_by_depth: bool (default True)
-            if True the antenna model is determined automatically depending on the depth of the antenna. This is done by 
-            appending e.g. '_InfFirn' to the antenna model name. 
-            if False, the antenna model as specified in the database is used. 
+            if True the antenna model is determined automatically depending on the depth of the antenna. This is done by
+            appending e.g. '_InfFirn' to the antenna model name.
+            if False, the antenna model as specified in the database is used.
         """
         if(source == 'sql'):
             self._db = buffer_db(in_memory=True)
         elif source == 'dictionary':
             self._db = TinyDB(storage=MemoryStorage)
-            self._db.purge()
+            self._db.truncate()
             stations_table = self._db.table('stations', cache_size=1000)
             for station in dictionary['stations'].values():
                 stations_table.insert(station)

--- a/NuRadioReco/modules/io/NuRadioRecoio.py
+++ b/NuRadioReco/modules/io/NuRadioRecoio.py
@@ -55,10 +55,10 @@ class NuRadioRecoio(object):
         self.__parse_detector = parse_detector
         self.__read_lock = False
         self.__max_open_files = max_open_files
+        self.__buffer_size = buffer_size
         self.openFile(filenames)
         self._current_file_id = 0
         self.logger.info("... finished in {:.0f} seconds".format(time.time() - t))
-        self.__buffer_size = buffer_size
 
     def _get_file(self, iF):
         if(iF not in self.__open_files):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ author-email = "work@c-glaser.de"
 home-page = "https://github.com/nu-radio/NuRadioReco"
 classifiers = ["License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"]
 requires = [
-    "tinydb",
+    "tinydb>=4.1.1",
     "tinydb-serialization",
     "aenum",
     "astropy<=2.0.14",


### PR DESCRIPTION
Fixes 2 issues related to reading eventfiles:

- Stops NuRadioRecoio from crashing because self.__buffer_size is not set if files are scanned
- The latest tinydb update renamed the Table.purge function to Table.truncate. https://tinydb.readthedocs.io/en/latest/changelog.html?highlight=purge#v4-0-0-2020-05-02
This also means, that we now require a newer tinydb version, which has been added to the pyproject and the documentation