### PR TITLE
Save git hashes

### DIFF
--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -4,6 +4,7 @@ import NuRadioReco.framework.station
 import NuRadioReco.framework.radio_shower
 import NuRadioReco.framework.hybrid_information
 import NuRadioReco.framework.parameters as parameters
+import NuRadioReco.utilities.version
 from six import itervalues
 import collections
 import logging
@@ -197,28 +198,15 @@ class Event:
     def serialize(self, mode):
         stations_pkl = []
         try:
-            import git
-            repo = git.Repo(NuRadioReco.__file__, search_parent_directories=True)
-            hash = repo.head.object.hexsha
+            hash = NuRadioReco.utilities.version.get_NuRadioReco_commit_hash()
             self.set_parameter(parameters.eventParameters.hash_NuRadioReco, hash)
         except:
             self.set_parameter(parameters.eventParameters.hash_NuRadioReco, None)
         try:
-            import git
-            import NuRadioMC
-            repo = git.Repo(NuRadioMC.__file__, search_parent_directories=True)
-            hash = repo.head.object.hexsha
+            hash = NuRadioReco.utilities.version.get_NuRadioMC_commit_hash()
             self.set_parameter(parameters.eventParameters.hash_NuRadioMC, hash)
         except:
             self.set_parameter(parameters.eventParameters.hash_NuRadioMC, None)
-        try:
-            import git
-            import radiotools
-            repo = git.Repo(radiotools.__file__, search_parent_directories=True)
-            hash = repo.head.object.hexsha
-            self.set_parameter(parameters.eventParameters.hash_radiotools, hash)
-        except:
-            self.set_parameter(parameters.eventParameters.hash_radiotools, None)
 
 
         for station in self.get_stations():

--- a/NuRadioReco/framework/event.py
+++ b/NuRadioReco/framework/event.py
@@ -196,6 +196,31 @@ class Event:
 
     def serialize(self, mode):
         stations_pkl = []
+        try:
+            import git
+            repo = git.Repo(NuRadioReco.__file__, search_parent_directories=True)
+            hash = repo.head.object.hexsha
+            self.set_parameter(parameters.eventParameters.hash_NuRadioReco, hash)
+        except:
+            self.set_parameter(parameters.eventParameters.hash_NuRadioReco, None)
+        try:
+            import git
+            import NuRadioMC
+            repo = git.Repo(NuRadioMC.__file__, search_parent_directories=True)
+            hash = repo.head.object.hexsha
+            self.set_parameter(parameters.eventParameters.hash_NuRadioMC, hash)
+        except:
+            self.set_parameter(parameters.eventParameters.hash_NuRadioMC, None)
+        try:
+            import git
+            import radiotools
+            repo = git.Repo(radiotools.__file__, search_parent_directories=True)
+            hash = repo.head.object.hexsha
+            self.set_parameter(parameters.eventParameters.hash_radiotools, hash)
+        except:
+            self.set_parameter(parameters.eventParameters.hash_radiotools, None)
+
+
         for station in self.get_stations():
             stations_pkl.append(station.serialize(mode))
 

--- a/NuRadioReco/framework/parameters.py
+++ b/NuRadioReco/framework/parameters.py
@@ -98,4 +98,3 @@ class eventParameters(Enum):
     sim_config = 1  # contents of the config file that the NuRadioMC simulation was run with
     hash_NuRadioReco = 2    # git hash of the NuRadioReco commit that the file was created with
     hash_NuRadioMC = 3  # git hash of the NuRadioMC commit that the file was created with
-    hash_radiotools = 4 # git hash of the radiotools commit that the file was created with

--- a/NuRadioReco/framework/parameters.py
+++ b/NuRadioReco/framework/parameters.py
@@ -96,3 +96,6 @@ class showerParameters(Enum):
 
 class eventParameters(Enum):
     sim_config = 1  # contents of the config file that the NuRadioMC simulation was run with
+    hash_NuRadioReco = 2    # git hash of the NuRadioReco commit that the file was created with
+    hash_NuRadioMC = 3  # git hash of the NuRadioMC commit that the file was created with
+    hash_radiotools = 4 # git hash of the radiotools commit that the file was created with

--- a/NuRadioReco/utilities/version.py
+++ b/NuRadioReco/utilities/version.py
@@ -1,0 +1,36 @@
+from subprocess import Popen, PIPE
+import os
+import re
+import logging
+logger = logging.getLogger("utilities.version")
+logging.basicConfig()
+
+
+def get_git_commit_hash(path):
+    try:
+        gitproc = Popen(['git', 'show'], stdout = PIPE, cwd=path)
+        (stdout, stderr) = gitproc.communicate()
+        h = stdout.decode('utf-8').split('\n')[0].split()[1]
+        check = re.compile(r"^[a-f0-9]{40}(:.+)?$", re.IGNORECASE)
+        if(not check.match(h)):
+            logging.error("NuRadioMC version could not be determined, returning None")
+            return "none"
+    except:
+        return "none"
+    return h
+
+def get_NuRadioMC_commit_hash():
+    """
+    returns the hash of the current commit of the NuRadioMC git repository
+    """
+    import NuRadioMC
+    path = os.path.dirname(NuRadioMC.__file__)
+    return get_git_commit_hash(path)
+
+def get_NuRadioReco_commit_hash():
+    """
+    returns the hash of the current commit of the NuRadioReco git repository
+    """
+    import NuRadioReco
+    path = os.path.dirname(NuRadioReco.__file__)
+    return get_git_commit_hash(path)

--- a/changelog.txt
+++ b/changelog.txt
@@ -38,6 +38,7 @@ new features:
 -Trigger times now include the time with respect to the first interaction (vertex times)
 -Analog to digital converter module added
 -Improved calculation of the diode noise parameters
+-Save the git hashes of the NuRadioReco, NuRadioMC and radiotools version a .nur file was created with
 
 Detector description can be stored in .nur files
 Large overhaul of the event structure. Adds shower classes and hybrid detector information.


### PR DESCRIPTION
Using GitPython (https://gitpython.readthedocs.io/en/stable/) we can get the git hash of NuRadioReco, NuRadioMC and radiotools and store them as an event parameter. This way, we can later tell which exact software version a .nur file was created with