### PR TITLE
Fix bug voltage to efield converter

### DIFF
--- a/NuRadioReco/modules/voltageToEfieldConverter.py
+++ b/NuRadioReco/modules/voltageToEfieldConverter.py
@@ -35,12 +35,11 @@ def get_array_of_channels(station, use_channels, det, zenith, azimuth,
         antenna_position = det.get_relative_position(station_id, channel_id)
         # determine refractive index of signal propagation speed between antennas
         refractive_index = ice.get_refractive_index(1, site)  # if signal comes from above, in-air propagation speed
-        if station.get_sim_station():
-            if station.get_sim_station().is_cosmic_ray():
-                if(zenith > 0.5 * np.pi):
-                    refractive_index = ice.get_refractive_index(antenna_position[2], site)  # if signal comes from below, use refractivity at antenna position
-            if station.get_sim_station().is_neutrino():
-                refractive_index = ice.get_refractive_index(antenna_position[2], site)
+        if station.is_cosmic_ray():
+            if(zenith > 0.5 * np.pi):
+                refractive_index = ice.get_refractive_index(antenna_position[2], site)  # if signal comes from below, use refractivity at antenna position
+        if station.is_neutrino():
+            refractive_index = ice.get_refractive_index(antenna_position[2], site)
         time_shift = -geo_utl.get_time_delay_from_direction(zenith, azimuth, antenna_position, n=refractive_index)
         t_geos[iCh] = time_shift
         t_cables[iCh] = channel.get_trace_start_time()

--- a/NuRadioReco/modules/voltageToEfieldConverter.py
+++ b/NuRadioReco/modules/voltageToEfieldConverter.py
@@ -35,11 +35,12 @@ def get_array_of_channels(station, use_channels, det, zenith, azimuth,
         antenna_position = det.get_relative_position(station_id, channel_id)
         # determine refractive index of signal propagation speed between antennas
         refractive_index = ice.get_refractive_index(1, site)  # if signal comes from above, in-air propagation speed
-        if station.get_sim_station().is_cosmic_ray():
-            if(zenith > 0.5 * np.pi):
-                refractive_index = ice.get_refractive_index(antenna_position[2], site)  # if signal comes from below, use refractivity at antenna position
-        if station.get_sim_station().is_neutrino():
-            refractive_index = ice.get_refractive_index(antenna_position[2], site)
+        if station.get_sim_station():
+            if station.get_sim_station().is_cosmic_ray():
+                if(zenith > 0.5 * np.pi):
+                    refractive_index = ice.get_refractive_index(antenna_position[2], site)  # if signal comes from below, use refractivity at antenna position
+            if station.get_sim_station().is_neutrino():
+                refractive_index = ice.get_refractive_index(antenna_position[2], site)
         time_shift = -geo_utl.get_time_delay_from_direction(zenith, azimuth, antenna_position, n=refractive_index)
         t_geos[iCh] = time_shift
         t_cables[iCh] = channel.get_trace_start_time()

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,10 @@ please update the categories "new features" and "bugfixes" before a pull request
 
 version 1.2
 new features:
-- users can specify a different bandwidth for each channel in the channelBandPassFilter and channelGenericNoiseAdder module 
+- users can specify a different bandwidth for each channel in the channelBandPassFilter and channelGenericNoiseAdder module
+
+bug fixes:
+- Added if check in voltageToEfieldConverter.py under method get_array_of_channels() to see if sim station is initialized
 
 version 1.1.2 -
 


### PR DESCRIPTION
method get_array_of_channels() in voltageToEfieldConverter.py had an if statement that required a sim_station to run. I first added an if statement to check if a sim_station exists, so that this code could be executed without requiring a sim_station
