### PR TITLE
Hides astropy Erfa warnings

### DIFF
--- a/NuRadioReco/detector/detector.py
+++ b/NuRadioReco/detector/detector.py
@@ -11,8 +11,12 @@ import astropy.time
 from datetime import datetime
 from tinydb_serialization import Serializer
 import six  # # used for compatibility between py2 and py3
+import warnings
+from astropy.utils.exceptions import ErfaWarning
 logger = logging.getLogger('NuRadioReco.detector')
 
+
+warnings.filterwarnings('ignore', category=ErfaWarning)
 
 class DateTimeSerializer(Serializer):
     """


### PR DESCRIPTION
Disables all astropy warnings of the class ErfaWarning. This gets rid of the 'dubious year' warning.