### PR TITLE
Hardcoded channel IDs

### DIFF
--- a/NuRadioReco/modules/channelResampler.py
+++ b/NuRadioReco/modules/channelResampler.py
@@ -52,7 +52,7 @@ class channelResampler:
         """
         is_sim_station = isinstance(station, NuRadioReco.framework.sim_station.SimStation)
         if is_sim_station:  # sim_stations are structured differently
-            orig_binning = 1. / station.get_channel(det.get_channel_ids(det.get_default_station_id())[0]).get_sampling_rate()  # assume that all channels have the same sampling rate
+            orig_binning = 1. / station.get_channel(det.get_channel_ids(det.get_default_station_id())[0])[0].get_sampling_rate()  # assume that all channels have the same sampling rate
         else:
             orig_binning = 1. / station.get_channel(det.get_channel_ids(det.get_default_station_id())[0]).get_sampling_rate()
         target_binning = 1. / sampling_rate

--- a/NuRadioReco/modules/channelResampler.py
+++ b/NuRadioReco/modules/channelResampler.py
@@ -52,9 +52,9 @@ class channelResampler:
         """
         is_sim_station = isinstance(station, NuRadioReco.framework.sim_station.SimStation)
         if is_sim_station:  # sim_stations are structured differently
-            orig_binning = 1. / station.get_channel(det.get_channel_ids(det.get_default_station_id())[0])[0].get_sampling_rate()  # assume that all channels have the same sampling rate
+            orig_binning = 1. / station.get_channel(det.get_channel_ids(station.get_id())[0])[0].get_sampling_rate()  # assume that all channels have the same sampling rate
         else:
-            orig_binning = 1. / station.get_channel(det.get_channel_ids(det.get_default_station_id())[0]).get_sampling_rate()
+            orig_binning = 1. / station.get_channel(det.get_channel_ids(station.get_id())[0]).get_sampling_rate()
         target_binning = 1. / sampling_rate
         resampling_factor = fractions.Fraction(Decimal(orig_binning / target_binning)).limit_denominator(self.__max_upsampling_factor)
         if resampling_factor == self.__max_upsampling_factor:

--- a/NuRadioReco/modules/channelResampler.py
+++ b/NuRadioReco/modules/channelResampler.py
@@ -52,9 +52,9 @@ class channelResampler:
         """
         is_sim_station = isinstance(station, NuRadioReco.framework.sim_station.SimStation)
         if is_sim_station:  # sim_stations are structured differently
-            orig_binning = 1. / station.get_channel(0)[0].get_sampling_rate()  # assume that all channels have the same sampling rate
+            orig_binning = 1. / station.get_channel(det.get_channel_ids(det.get_default_station_id())[0]).get_sampling_rate()  # assume that all channels have the same sampling rate
         else:
-            orig_binning = 1. / station.get_channel(0).get_sampling_rate()
+            orig_binning = 1. / station.get_channel(det.get_channel_ids(det.get_default_station_id())[0]).get_sampling_rate()
         target_binning = 1. / sampling_rate
         resampling_factor = fractions.Fraction(Decimal(orig_binning / target_binning)).limit_denominator(self.__max_upsampling_factor)
         if resampling_factor == self.__max_upsampling_factor:

--- a/NuRadioReco/modules/io/coreas/readCoREASShower.py
+++ b/NuRadioReco/modules/io/coreas/readCoREASShower.py
@@ -109,7 +109,7 @@ class readCoREASShower:
                 if self.__det is None:
                     sim_station = coreas.make_sim_station(station_id, corsika, observer, channel_ids=[0, 1, 2])
                 else:
-                    sim_station = coreas.make_sim_station(station_id, corsika, observer, channel_ids=self.__det.get_channel_ids(station_id))
+                    sim_station = coreas.make_sim_station(station_id, corsika, observer, channel_ids=self.__det.get_channel_ids(self.__det.get_default_station_id()))
                 station.set_sim_station(sim_station)
                 evt.set_station(station)
                 if self.__det is not None:

--- a/NuRadioReco/modules/io/coreas/readCoREASShower.py
+++ b/NuRadioReco/modules/io/coreas/readCoREASShower.py
@@ -106,8 +106,10 @@ class readCoREASShower:
                 station_id = antenna_id(name, idx)  # returns proper station id if possible
 
                 station = NuRadioReco.framework.station.Station(station_id)
-                sim_station = coreas.make_sim_station(station_id, corsika, observer, channel_ids=[0, 1, 2])
-
+                if self.__det is None:
+                    sim_station = coreas.make_sim_station(station_id, corsika, observer, channel_ids=[0, 1, 2])
+                else:
+                    sim_station = coreas.make_sim_station(station_id, corsika, observer, channel_ids=self.__det.get_channel_ids(station_id))
                 station.set_sim_station(sim_station)
                 evt.set_station(station)
                 if self.__det is not None:

--- a/NuRadioReco/modules/trigger/envelopeTrigger.py
+++ b/NuRadioReco/modules/trigger/envelopeTrigger.py
@@ -76,7 +76,7 @@ class triggerSimulator:
 
         t = time.time()  # absolute time of system
 
-        sampling_rate = station.get_channel(0).get_sampling_rate()
+        sampling_rate = station.get_channel(det.get_channel_ids(det.get_default_station_id())[0]).get_sampling_rate()
         dt = 1. / sampling_rate
 
         triggered_bins_channels = []

--- a/NuRadioReco/modules/trigger/envelopeTrigger.py
+++ b/NuRadioReco/modules/trigger/envelopeTrigger.py
@@ -76,7 +76,7 @@ class triggerSimulator:
 
         t = time.time()  # absolute time of system
 
-        sampling_rate = station.get_channel(det.get_channel_ids(det.get_default_station_id())[0]).get_sampling_rate()
+        sampling_rate = station.get_channel(det.get_channel_ids(station.get_id())[0]).get_sampling_rate()
         dt = 1. / sampling_rate
 
         triggered_bins_channels = []


### PR DESCRIPTION
In some places, channel IDs were hardcoded. This PR makes the code more flexible by reading the available channels from the detector description and picking one of them