### PR TITLE
Adds function to get the amp response directly from the detector class

### DIFF
--- a/NuRadioReco/detector/ARIANNA/analog_components.py
+++ b/NuRadioReco/detector/ARIANNA/analog_components.py
@@ -160,3 +160,7 @@ def get_cable_response(frequencies, path=os.path.dirname(os.path.realpath(__file
     cable_phase = np.exp(1j * cable_phase)
 
     return cable_amp * cable_phase
+
+
+def get_available_amplifiers():
+    return ['100', '200', '300']

--- a/NuRadioReco/detector/RNO_G/analog_components.py
+++ b/NuRadioReco/detector/RNO_G/analog_components.py
@@ -51,3 +51,7 @@ def load_amp_response(amp_type='rno_surface', path=os.path.dirname(os.path.realp
     amp_response['phase'] = get_amp_phase
 
     return amp_response
+
+
+def get_available_amplifiers():
+    return ['iglu', 'rno_surface']

--- a/NuRadioReco/detector/detector.py
+++ b/NuRadioReco/detector/detector.py
@@ -696,8 +696,6 @@ class Detector(object):
         frequencies: array of floats
             The frequency array for which the amplifier response shall be returned
         """
-        rno_amps = ['iglu', 'rno_surface']
-        arianna_amps = ['100', '200', '300']
         res = self.__get_channel(station_id, channel_id)
         amp_type = None
         if 'amp_type' in res.keys():
@@ -708,11 +706,14 @@ class Detector(object):
                     station_id,
                     channel_id
                 ))
-        if amp_type in rno_amps:
+        amp_response_functions = None
+        if amp_type in NuRadioReco.detector.RNO_G.analog_components.get_available_amplifiers():
             amp_response_functions = NuRadioReco.detector.RNO_G.analog_components.load_amp_response(amp_type)
-        elif amp_type in arianna_amps:
+        if amp_type in NuRadioReco.detector.ARIANNA.analog_components.get_available_amplifiers():
+            if amp_response_functions is not None:
+                raise ValueError('Amplifier name {} is not unique'.format(amp_type))
             amp_response_functions = NuRadioReco.detector.ARIANNA.analog_components.load_amplifier_response(amp_type)
-        else:
+        if amp_response_functions is None:
             raise ValueError('Amplifier of type {} not found'.format(amp_type))
         amp_gain = amp_response_functions['gain'](frequencies)
         amp_phase = amp_response_functions['phase'](frequencies)

--- a/NuRadioReco/detector/detector.py
+++ b/NuRadioReco/detector/detector.py
@@ -1,5 +1,7 @@
 import numpy as np
 from NuRadioReco.utilities import units
+import NuRadioReco.detector.RNO_G.analog_components
+import NuRadioReco.detector.ARIANNA.analog_components
 from radiotools import helper as hp
 import os
 import logging
@@ -680,6 +682,41 @@ class Detector(object):
         """
         res = self.__get_channel(station_id, channel_id)
         return res['amp_reference_measurement']
+
+    def get_amplifier_response(self, station_id, channel_id, frequencies):
+        """
+        Returns the amplifier response for the amplifier of a given channel
+
+        Parameters:
+        ---------------
+        station_id: int
+            The ID of the station
+        channel_id: int
+            The ID of the channel
+        frequencies: array of floats
+            The frequency array for which the amplifier response shall be returned
+        """
+        rno_amps = ['iglu', 'rno_surface']
+        arianna_amps = ['100', '200', '300']
+        res = self.__get_channel(station_id, channel_id)
+        amp_type = None
+        if 'amp_type' in res.keys():
+            amp_type = res['amp_type']
+        if amp_type is None:
+            raise ValueError(
+                'Amplifier type for station {}, channel {} not in detector description'.format(
+                    station_id,
+                    channel_id
+                ))
+        if amp_type in rno_amps:
+            amp_response_functions = NuRadioReco.detector.RNO_G.analog_components.load_amp_response(amp_type)
+        elif amp_type in arianna_amps:
+            amp_response_functions = NuRadioReco.detector.ARIANNA.analog_components.load_amplifier_response(amp_type)
+        else:
+            raise ValueError('Amplifier of type {} not found'.format(amp_type))
+        amp_gain = amp_response_functions['gain'](frequencies)
+        amp_phase = amp_response_functions['phase'](frequencies)
+        return amp_gain * amp_phase
 
     def get_sampling_frequency(self, station_id, channel_id):
         """


### PR DESCRIPTION
It's annoying to always use the analog_components modules manually every time you need the amp response. This PR simplifies things