### PR TITLE
Adding traces

### DIFF
--- a/NuRadioReco/autodoc/pages/event_structure.rst
+++ b/NuRadioReco/autodoc/pages/event_structure.rst
@@ -2,10 +2,10 @@ Data Structure
 ===========================
 
 .nur Files and How to Use Them
-----------------------
+----------------------------------
 
 Philosophy and Basic Structure
-____________
+__________________________________
   NuRadioReco comes with its own input and output format, called *.nur*. With
   the obvious exception of reading in data from other file formats, like
   *CoREAS* or the *SnowShovel* format of the *ARIANNA* experiment, every
@@ -32,7 +32,7 @@ ____________
       trace = channel.get_trace()
 
 Reading and Writing .nur Files
-____________
+________________________________
 
   Reading and writing *.nur* files is done by dedicated IO modules.
   Writing events is done by the eventWriter module. To save disc space it offers
@@ -144,7 +144,7 @@ ____________
   showers and stations as well as the event ID and run number.
 
 Radio Shower
-____________
+______________
   A `Radio Shower <../NuRadioReco.framework.html#module-NuRadioReco.framework.radio_shower>`_ is used to
   hold reconstructed shower parameters via the parameter storage. It should only be
   used for properties reconstructed from the radio signal, for properties from a simulated
@@ -167,6 +167,7 @@ ____________
   reconstructed at the station level, i.e. reconstructed from the data of a single station.
 
   It can be accessed by the ``get_station`` and ``get_stations`` methods of the ``Event`` class
+
 Trigger
 ____________
 
@@ -193,12 +194,18 @@ ____________
   of the parent ``Station`` and can be changes using the ``set_trace_start_time``
   method, which changes the starting time of the trace.
 
+  The add operator (+) is defined for 2 ``BaseTrace`` objects. It will return a new ``BaseTrace``
+  object containing the sum of both traces. The length of the new trace is chosen so that
+  it is long enough to contain both traces. If the traces have different sampling rates,
+  the one with the lower sampling rate will be upsampled to match the other one.
+  Since this property is inherited, + is defined for both channels and electric fields.
+
 
   The ``Trace`` class is not used by itself, but serves as parent class for both
   the ``Channel`` and ``ElectricField`` classes.
 
 Electric Field
-____________
+_______________
   The `ElectricField <../NuRadioReco.framework.html#module-NuRadioReco.framework.electric_field>`_
   is used to store information about electric fields, which can be accessed via the parameter storage
   and methods inherited from the ``BaseTrace`` class.
@@ -224,7 +231,7 @@ ____________
 
 
 Hybrid Information
-____________
+___________________
   As many radio detectors are built as part of a hybrid detector whose data may be used in the
   radio event reconstruction, a way to make this data accessible in NuRadioReco is needed. The
   `HybridInformation <../NuRadioReco.framework.html#module-NuRadioReco.framework.hybrid_information>`_
@@ -238,7 +245,7 @@ ____________
   It can be accessed via the ``get_hybrid_information'' method of the ``Event`` class.
 
 Hybrid Shower
-____________
+______________
   The `HybridShower <../NuRadioReco.framework.html#module-NuRadioReco.framework.hybrid_shower>`_ is
   used to store information about a shower that was reconstructed with a complementary detector,
   mainly via the parameter storage.
@@ -247,7 +254,7 @@ ____________
   ``HybridInformation`` class.
 
 Hybrid Detector
-____________
+_________________
   A ``HybridDetector`` can be used to store more detailed and experiment-specific information
   about a complementary detector. The diversity of hybrid radio detectors makes it
   impractical to provide this functionality inside NuRadioReco itself, but a custom

--- a/NuRadioReco/framework/base_trace.py
+++ b/NuRadioReco/framework/base_trace.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import, division, print_function
 import numpy as np
 import logging
-from NuRadioReco.utilities import fft
+import fractions
+from NuRadioReco.utilities import fft, trace_utilities
+import scipy.signal
+import copy
 try:
     import cPickle as pickle
 except ImportError:
@@ -120,7 +123,7 @@ class BaseTrace:
             length = (self._frequency_spectrum.shape[-1] - 1) * 2
         return length
 
-    def apply_time_shift(self, delta_t):
+    def apply_time_shift(self, delta_t, silent=False):
         """
         Uses the fourier shift theorem to apply a time shift to the trace
         Note that this is a cyclic shift, which means the trace will wrap
@@ -130,8 +133,12 @@ class BaseTrace:
         --------------------
         delta_t: float
             Time by which the trace should be shifted
+        silent: boolean (default:False)
+            Turn off warnings if time shift is larger than 10% of trace length
+            Only use this option if you are sure that your trace is long enough
+            to acommodate the time shift
         """
-        if delta_t > .1 * self.get_number_of_samples() / self.get_sampling_rate():
+        if delta_t > .1 * self.get_number_of_samples() / self.get_sampling_rate() and not silent:
             logger.warning('Trace is shifted by more than 10% of its length')
         spec = self.get_frequency_spectrum()
         spec *= np.exp(-2.j * np.pi * delta_t * self.get_frequencies())
@@ -148,3 +155,73 @@ class BaseTrace:
         self.set_trace(data['time_trace'], data['sampling_rate'])
         if('trace_start_time' in data.keys()):
             self.set_trace_start_time(data['trace_start_time'])
+
+    def __add__(self, x):
+        if not isinstance(x, BaseTrace):
+            raise TypeError('+ operator is only defined for 2 BaseTrace objects')
+        if self.get_trace() is None or x.get_trace() is None:
+            raise ValueError('One of the trace objects has no trace set')
+        if self.get_trace().ndim != x.get_trace().ndim:
+            raise ValueError('Traces have different dimensions')
+        trace_1 = copy.copy(self.get_trace())
+        trace_2 = copy.copy(x.get_trace())
+        if self.get_sampling_rate() != x.get_sampling_rate():
+            if self.get_sampling_rate() > x.get_sampling_rate():
+                sampling_rate = self.get_sampling_rate()
+                resampling_factor = fractions.Fraction(self.get_sampling_rate() / x.get_sampling_rate())
+                if (resampling_factor.numerator != 1):
+                    trace_2 = scipy.signal.resample(trace_2, resampling_factor.numerator * len(trace_2))
+                if(resampling_factor.denominator != 1):
+                    trace_2 = scipy.signal.resample(trace_2, len(trace_2) // resampling_factor.denominator)
+            else:
+                sampling_rate = x.get_sampling_rate()
+                resampling_factor = fractions.Fraction(x.get_sampling_rate() / self.get_sampling_rate())
+                if (resampling_factor.numerator != 1):
+                    trace_1 = scipy.signal.resample(trace_1, resampling_factor.numerator * len(trace_1))
+                if(resampling_factor.denominator != 1):
+                    trace_1 = scipy.signal.resample(trace_1, len(trace_1) // resampling_factor.denominator)
+        else:
+            sampling_rate = self.get_sampling_rate()
+        if self.get_trace_start_time() <= x.get_trace_start_time():
+            trace_start = self.get_trace_start_time()
+            time_offset = x.get_trace_start_time() - self.get_trace_start_time()
+            i_start = int(round(time_offset * sampling_rate))
+            if trace_1.ndim == 1:
+                trace_length = max(trace_1.shape[0], i_start + trace_2.shape[0])
+                trace_length += trace_length % 2
+                early_trace = np.zeros(trace_length)
+                early_trace[:trace_1.shape[0]] = trace_1
+                late_trace = np.zeros(trace_length)
+                late_trace[:trace_2.shape[0]] = trace_2
+            else:
+                trace_length = max(trace_1.shape[1], i_start + trace_2.shape[1])
+                trace_length += trace_length % 2
+                early_trace = np.zeros((trace_1.shape[0], trace_length))
+                early_trace[:, :trace_1.shape[1]] = trace_1
+                late_trace = np.zeros((trace_2.shape[0], trace_length))
+                late_trace[:, :trace_2.shape[1]] = trace_2
+        else:
+            trace_start = x.get_trace_start_time()
+            time_offset = self.get_trace_start_time() - x.get_trace_start_time()
+            i_start = int(round(time_offset * sampling_rate))
+            if trace_1.ndim == 1:
+                trace_length = max(trace_2.shape[0], i_start + trace_1.shape[0])
+                trace_length += trace_length % 2
+                early_trace = np.zeros(trace_length)
+                early_trace[:trace_2.shape[0]] = trace_2
+                late_trace = np.zeros(trace_length)
+                late_trace[:trace_1.shape[0]] = trace_1
+            else:
+                trace_length = max(trace_2.shape[1], i_start + trace_1.shape[1])
+                trace_length += trace_length % 2
+                early_trace = np.zeros((trace_2.shape[0], trace_length))
+                early_trace[:, :trace_2.shape[1]] = trace_2
+                late_trace = np.zeros((trace_1.shape[0], trace_length))
+                late_trace[:, :trace_1.shape[1]] = trace_1
+        late_trace_object = BaseTrace()
+        late_trace_object.set_trace(late_trace, sampling_rate)
+        late_trace_object.apply_time_shift(time_offset, True)
+        new_trace = BaseTrace()
+        new_trace.set_trace(early_trace + late_trace_object.get_trace(), sampling_rate)
+        new_trace.set_trace_start_time(trace_start)
+        return new_trace

--- a/NuRadioReco/framework/base_trace.py
+++ b/NuRadioReco/framework/base_trace.py
@@ -191,6 +191,7 @@ class BaseTrace:
         else:
             sampling_rate = self.get_sampling_rate()
 
+        # Figure out which of the traces has the earlier trace start time
         if self.get_trace_start_time() <= x.get_trace_start_time():
             first_trace = trace_1
             second_trace = trace_2
@@ -199,18 +200,24 @@ class BaseTrace:
             first_trace = trace_2
             second_trace = trace_1
             trace_start = x.get_trace_start_time()
+        # Calculate the difference in the trace start time between the traces and the number of
+        # samples that time difference corresponds to
         time_offset = np.abs(x.get_trace_start_time() - self.get_trace_start_time())
         i_start = int(round(time_offset * sampling_rate))
         # We have to distinguish 2 cases: Trace is 1D (channel) or 2D(E-field)
         # and treat them differently
         if trace_1.ndim == 1:
+            # Calculate length the new trace needs to hold both input traces
             trace_length = max(first_trace.shape[0], i_start + second_trace.shape[0])
+            # Make sure trace has an even number of samples
             trace_length += trace_length % 2
+            # Put both pulses at the start of their own traces for now. We correct for different start times later
             early_trace = np.zeros(trace_length)
             early_trace[:first_trace.shape[0]] = first_trace
             late_trace = np.zeros(trace_length)
             late_trace[:second_trace.shape[0]] = second_trace
         else:
+            # Same as in the if bracket, but for a 2D trace (like an E-field)
             trace_length = max(first_trace.shape[1], i_start + second_trace.shape[1])
             trace_length += trace_length % 2
             early_trace = np.zeros((first_trace.shape[0], trace_length))


### PR DESCRIPTION
With the electric fields and simChannels split up into individual traces per shower, we need an easy way to get the sum of all these traces to see what it all looks like together.
With this PR, the + operator is defined for 2 BaseTrace objects to return a new BaseTrace object containing the sum of the two traces. I think using the + operator works well here, since it is convenient, doesn't require importing anything and returns what one would intuitively guess the sum of two trace objects should be.
For example, plotting the sum of two traces would look like this:
tr = trace_1 + trace_2
ax1.plot(tr.get_times(), tr.get_trace())
ax2.plot(tr.get_frequencies(), abs(tr.get_frequency_spectrum())