### PR TITLE
SimChannels for cosmic ray events

### DIFF
--- a/NuRadioReco/modules/efieldToVoltageConverter.py
+++ b/NuRadioReco/modules/efieldToVoltageConverter.py
@@ -112,6 +112,9 @@ class efieldToVoltageConverter():
                         index_of_refraction = ice.get_refractive_index(antenna_position[2], site)
                     else:  # signal is coming from above, so we take IOR of air
                         index_of_refraction = ice.get_refractive_index(1, site)
+                    # For cosmic ray events, we only have one electric field for all channels, so we have to account
+                    # for the difference in signal travel between channels. IMPORTANT: This is only accurate
+                    # if all channels have the same z coordinate
                     travel_time_shift = geo_utl.get_time_delay_from_direction(
                         sim_station.get_parameter(stnp.zenith),
                         sim_station.get_parameter(stnp.azimuth),

--- a/NuRadioReco/modules/efieldToVoltageConverterPerEfield.py
+++ b/NuRadioReco/modules/efieldToVoltageConverterPerEfield.py
@@ -67,7 +67,9 @@ class efieldToVoltageConverterPerEfield():
                         index_of_refraction = ice.get_refractive_index(antenna_position[2], site)
                     else:  # signal is coming from above, so we take IOR of air
                         index_of_refraction = ice.get_refractive_index(1, site)
-
+                    # For cosmic ray events, we only have one electric field for all channels, so we have to account
+                    # for the difference in signal travel between channels. IMPORTANT: This is only accurate
+                    # if all channels have the same z coordinate
                     travel_time_shift = geometryUtilities.get_time_delay_from_direction(
                         zenith,
                         azimuth,


### PR DESCRIPTION
Makes the efieldToVoltageConverterPerEfield consider signal travel times between channels for cosmic ray events, so simChannels can be used for CR as well