### PR TITLE
Parameter error serialization

### DIFF
--- a/NuRadioReco/framework/base_station.py
+++ b/NuRadioReco/framework/base_station.py
@@ -240,7 +240,7 @@ class BaseStation():
                 'format': self._station_time.format
             }
         data = {'_parameters': NuRadioReco.framework.parameter_serialization.serialize(self._parameters),
-                '_parameter_covariances': self._parameter_covariances,
+                '_parameter_covariances': NuRadioReco.framework.parameter_serialization.serialize_covariances(self._parameter_covariances),
                 '_ARIANNA_parameters': self._ARIANNA_parameters,
                 '_station_id': self._station_id,
                 '_station_time': station_time_dict,
@@ -267,7 +267,7 @@ class BaseStation():
         self._parameters = NuRadioReco.framework.parameter_serialization.deserialize(data['_parameters'],
                                                                                      parameters.stationParameters)
 
-        self._parameter_covariances = data['_parameter_covariances']
+        self._parameter_covariances = NuRadioReco.framework.parameter_serialization.deserialize_covariances(data['_parameter_covariances'], parameters.stationParameters)
         if ('_ARIANNA_parameters') in data:
             self._ARIANNA_parameters = data['_ARIANNA_parameters']
 

--- a/NuRadioReco/framework/electric_field.py
+++ b/NuRadioReco/framework/electric_field.py
@@ -129,6 +129,7 @@ class ElectricField(NuRadioReco.framework.base_trace.BaseTrace):
         else:
             base_trace_pkl = None
         data = {'parameters': NuRadioReco.framework.parameter_serialization.serialize(self._parameters),
+                'parameter_covariances': NuRadioReco.framework.parameter_serialization.serialize_covariances(self._parameter_covariances),
                 'channel_ids': self._channel_ids,
                 '_shower_id': self._shower_id,
                 '_ray_tracing_id': self._ray_tracing_id,
@@ -143,6 +144,8 @@ class ElectricField(NuRadioReco.framework.base_trace.BaseTrace):
         if 'position' in data:  # for backward compatibility
             self._position = data['position']
         self._parameters = NuRadioReco.framework.parameter_serialization.deserialize(data['parameters'], parameters.electricFieldParameters)
+        if 'parameter_covariances' in data:
+            self._parameter_covariances = NuRadioReco.framework.parameter_serialization.deserialize_covariances(data['parameter_covariances'], parameters.electricFieldParameters)
         self._channel_ids = data['channel_ids']
         if '_shower_id' in data.keys():
             self._shower_id = data['_shower_id']

--- a/NuRadioReco/framework/parameter_serialization.py
+++ b/NuRadioReco/framework/parameter_serialization.py
@@ -14,3 +14,25 @@ def deserialize(target_object, parameter_enum):
         if str(entry) in target_object:
             reply[entry] = target_object[str(entry)]
     return reply
+
+
+def serialize_covariances(target_object):
+    reply = {}
+    for entry in target_object:
+        reply[(str(entry[0]), str(entry[1]))] = target_object[entry]
+    return reply
+
+
+def deserialize_covariances(target_object, parameter_enum):
+    reply = {}
+    for entry in target_object:
+        first_key = None
+        second_key = None
+        for enum in parameter_enum:
+            if str(enum) == entry[0]:
+                first_key = enum
+            if str(enum) == entry[1]:
+                second_key = enum
+        if first_key is not None and second_key is not None:
+            reply[(first_key, second_key)] = target_object[entry]
+    return reply


### PR DESCRIPTION
Serializes the electric field parameter covariances so they are stored in .nur files.
Also improves the serialization of station parameter covariances so that files remain readable if parameters are removed.
The change to the station parameters is not backward compatible, but I don't think anyone was using them. Old files shoudl be readable anyway, just not the parameter errors.