### PR TITLE
Return copy of trace and spectrum

### DIFF
--- a/NuRadioReco/framework/base_trace.py
+++ b/NuRadioReco/framework/base_trace.py
@@ -35,7 +35,7 @@ class BaseTrace:
             self._time_trace = fft.freq2time(self._frequency_spectrum, self._sampling_rate)
             self.__time_domain_up_to_date = True
             self._frequency_spectrum = None
-        return self._time_trace
+        return np.copy(self._time_trace)
 
     def get_filtered_trace(self, passband, filter_type='butter', order=10):
         """
@@ -62,7 +62,7 @@ class BaseTrace:
             self._time_trace = None
 #             logger.debug("frequency spectrum has shape {}".format(self._frequency_spectrum.shape))
             self.__time_domain_up_to_date = False
-        return self._frequency_spectrum
+        return np.copy(self._frequency_spectrum)
 
     def set_trace(self, trace, sampling_rate):
         """


### PR DESCRIPTION
The get_trace and get_frequency_spectrum methods return a reference to self._time_trace or self._frequency_spectrum. This is dangerous, because modifying the returned traces can change the values stored by the trace object to change in unintuitive ways:
`
In [1]: import numpy as np                                                                           

In [2]: import NuRadioReco.modules.io.NuRadioRecoio                                                  

In [3]: io = NuRadioReco.modules.io.NuRadioRecoio.NuRadioRecoio(['output.nur'])                      

In [4]: channel = io.get_event_i(0).get_station(101).get_channel(0)                                  

In [5]: np.max(channel.get_trace())                                                                  
Out[5]: 9.21563751242359e-05

In [6]: spec = channel.get_frequency_spectrum()                                                      

In [7]: np.max(channel.get_trace())                                                                  
Out[7]: 9.215637512423589e-05

In [8]: spec *= 1.e6                                                                                 

In [9]: np.max(channel.get_trace())                                                                  
Out[9]: 9.215637512423589e-05

In [10]: spec = channel.get_frequency_spectrum()                                                     

In [11]: spec *= 1.e6                                                                                

In [12]: np.max(channel.get_trace())                                                                 
Out[12]: 92.15637512423588
`
Weather or not modifications to spec affect the trace stored in the channel depends on whether it is stored in the time or frequency domain. That is why the trace maximum changes in In[12] but not in In[9].
By returning a copy of the trace we can stop this from  happening.