### PR TITLE
add Vpols (center, wall, half) and Hpol (quadslot)

### DIFF
--- a/NuRadioReco/detector/antenna_models_hash.json
+++ b/NuRadioReco/detector/antenna_models_hash.json
@@ -44,5 +44,13 @@
 	"XFDTD_Vpol_CrossFeed_150mmHole_n1.78.pkl": "5d87513779cf2cb5d3309a9bb89dbb163d656114",
         "trislot_RNOG.pkl": "29ef63bc9f25da743dd85d33e5645fc6330f6675",
         "RNOG_vpol_v1_n1.73.pkl": "4bd0b5941b31c6c39fd6b438f005075b025fee8d",
-        "RNOG_vpol_v1_n1.4.pkl": "1b8be66b64f241d26e34567167318aa85c396f2a"
+        "RNOG_vpol_v1_n1.4.pkl": "1b8be66b64f241d26e34567167318aa85c396f2a", 
+        "vpol_4inch_half.pkl":
+        "f08d263233503f79e5be10c18bc7587b8b421c1d", 
+        "vpol_4inch_center.pkl":
+        "5f429ed9ed08175a7f75fd44422367d2278bf2e1", 
+        "vpol_4inch_wall.pkl":
+        "da24017eb80f7a68348a674be2c527457fe19992", 
+        "RNOG_quadslot.pkl":
+        "e9c4946dd2176489249c862f32ef272ab627dc28"
 }


### PR DESCRIPTION
Add new antenna models for RNOG to antenna_models_hash.json. 3 Vpols (1 centered, 1 half way and 1 at the wall of the bore hole) and 1 quad slot Hpol. 
