### PR TITLE
Adds option to specify max number of events per file in eventWriter

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ new features:
 - new coreas read in function to generate signals for a grid of stations
 - added simulation of galactic noise
 - new phased array trigger module
+- eventWriter: Add option to specify number of events per file
 
 bug fixes:
 - Added if check in voltageToEfieldConverter.py under method get_array_of_channels() to see if sim station is initialized


### PR DESCRIPTION
Adds an option to the eventWriter that lets you specify how many events should be written into one file.
This is useful when running reconstructions, because events can be split evenly between jobs, so all take roughly the same time.