### PR TITLE
Prevent interference between Detector instances

### DIFF
--- a/NuRadioReco/detector/detector.py
+++ b/NuRadioReco/detector/detector.py
@@ -33,10 +33,21 @@ class DateTimeSerializer(Serializer):
         return datetime.strptime(s, '%Y-%m-%dT%H:%M:%S')
 
 
-def buffer_db(in_memory, filename=None, serialization=None):
+def buffer_db(in_memory, filename=None):
     """
     buffers the complete SQL database into a TinyDB object (either in memory or into a local JSON file)
+    
+    Parameters
+    ----------
+    in_memory: bool
+        if True: the mysql database will be buffered as a tiny tb object that only exists in memory
+        if False: the mysql database will be buffered as a tiny tb object and saved in a local json file
+    filename: string
+        only relevant if `in_memory = True`: the filename of the json file of the tiny db object
+    
     """
+    serialization = SerializationMiddleware()
+    serialization.register_serializer(DateTimeSerializer(), 'TinyDate')
     logger.info("buffering SQL database on-the-fly")
     if in_memory:
         db = TinyDB(storage=MemoryStorage)

--- a/NuRadioReco/detector/detector.py
+++ b/NuRadioReco/detector/detector.py
@@ -36,7 +36,7 @@ class DateTimeSerializer(Serializer):
 def buffer_db(in_memory, filename=None):
     """
     buffers the complete SQL database into a TinyDB object (either in memory or into a local JSON file)
-    
+
     Parameters
     ----------
     in_memory: bool
@@ -44,7 +44,6 @@ def buffer_db(in_memory, filename=None):
         if False: the mysql database will be buffered as a tiny tb object and saved in a local json file
     filename: string
         only relevant if `in_memory = True`: the filename of the json file of the tiny db object
-    
     """
     serialization = SerializationMiddleware()
     serialization.register_serializer(DateTimeSerializer(), 'TinyDate')


### PR DESCRIPTION
Turns the SerializationMiddleware from TinyDB from a global variable into an attribute of the Detector class. This makes sure that each detector instance gets its own SerializationMiddleware object, to prevent interference between Detector instances.

Fix for #288 

@cg-laser This breaks the script NuRadioReco/detector/sql_to_json.py
I don't understand what this script is for or if we even need it any more.