### PR TITLE
Fixing expected polarization calculation

### DIFF
--- a/NuRadioReco/modules/voltageToAnalyticEfieldConverter.py
+++ b/NuRadioReco/modules/voltageToAnalyticEfieldConverter.py
@@ -613,7 +613,7 @@ class voltageToAnalyticEfieldConverter:
         exp_efield = hp.get_lorentzforce_vector(zenith, azimuth, hp.get_magnetic_field_vector(site))
         cs = coordinatesystems.cstrafo(zenith, azimuth, site=site)
         exp_efield_onsky = cs.transform_from_ground_to_onsky(exp_efield)
-        exp_pol_angle = np.arctan2(abs(exp_efield_onsky[2]), abs(exp_efield_onsky[1]))
+        exp_pol_angle = np.arctan2(abs(exp_efield_onsky[2]), abs(exp_efield_onsky[1]))   # taking absolute value before doing arctan. Otherwise exp_pol_angle can sometimes be negative, other times even < -90deg, which does not make sense
         logger.info("expected polarization angle = {:.1f}".format(exp_pol_angle / units.deg))
         electric_field.set_parameter(efp.polarization_angle_expectation, exp_pol_angle)
         res_amp_second_order = opt.minimize(

--- a/NuRadioReco/modules/voltageToAnalyticEfieldConverter.py
+++ b/NuRadioReco/modules/voltageToAnalyticEfieldConverter.py
@@ -613,7 +613,7 @@ class voltageToAnalyticEfieldConverter:
         exp_efield = hp.get_lorentzforce_vector(zenith, azimuth, hp.get_magnetic_field_vector(site))
         cs = coordinatesystems.cstrafo(zenith, azimuth, site=site)
         exp_efield_onsky = cs.transform_from_ground_to_onsky(exp_efield)
-        exp_pol_angle = np.arctan2(exp_efield_onsky[2], exp_efield_onsky[1])
+        exp_pol_angle = np.arctan2(abs(exp_efield_onsky[2]), abs(exp_efield_onsky[1]))
         logger.info("expected polarization angle = {:.1f}".format(exp_pol_angle / units.deg))
         electric_field.set_parameter(efp.polarization_angle_expectation, exp_pol_angle)
         res_amp_second_order = opt.minimize(

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ new features:
 bug fixes:
 - Added if check in voltageToEfieldConverter.py under method get_array_of_channels() to see if sim station is initialized
 - trigger modules set the trigger time to 0 in case not trigger was recorded. This lead to problems, and wrong total trigger times, if multiple triggers were recorded. Now, no trigger time is set if not trigger was found. 
+- Under run() in voltageToEfieldConverter.py, for the calculation of expected polarization, taking absolute value of ephi and etheta before doing arctan2(), so that the polarization is always between 0deg to 90deg
 
 version 1.1.2 -
 


### PR DESCRIPTION
Expected polarization calculation is changed from:

`exp_pol_angle = np.arctan2(exp_efield_onsky[2], exp_efield_onsky[1])`

to

`exp_pol_angle = np.arctan2(abs(exp_efield_onsky[2]), abs(exp_efield_onsky[1]))`

Namely, taking the absolute values of etheta and ephi before taking the arctan of them. Otherwise, for some cosmic ray events, the expected polarization would be negative, with some extreme ones being even less than -90deg. However, the polarization should stay between 0deg to 90deg.